### PR TITLE
wrap post response correctly

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -37,7 +37,7 @@ Mappings:
       TableWriteCapacity: 25
     PROD:
       TableReadCapacity: 75
-      TableWriteCapacity: 75
+      TableWriteCapacity: 4500
 
 Resources:
   SaveForLaterDynamoTable:

--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -17,7 +17,7 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
          syncedPrefs.savedArticles.foreach ( sp =>
             logger.debug(s"Returning found: ${sp.articles.size} articles")
          )
-         Future.successful { okSycedPrefsResponse(syncedPrefs) }
+         Future.successful { okSyncedPrefsResponse(syncedPrefs) }
        case Success(None) =>
          logger.debug("No articles found")
          Future.successful { emptyArticlesResponse  }

--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -17,7 +17,7 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
          syncedPrefs.savedArticles.map( sp =>
             logger.debug(s"Returning found: ${sp.articles.size} articles")
          )
-         Future { okSavedArticlesResponse(syncedPrefs) }
+         Future { okSycedPrefsResponse(syncedPrefs) }
        case Success(None) =>
          logger.debug("No articles found")
          Future { emptyArticlesResponse  }

--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -14,13 +14,13 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
 
      val futureResponse =  fetchSavedArticles.retrieveForUser(lambdaRequest.headers).transformWith {
        case Success(Some(syncedPrefs)) =>
-         syncedPrefs.savedArticles.map( sp =>
+         syncedPrefs.savedArticles.foreach ( sp =>
             logger.debug(s"Returning found: ${sp.articles.size} articles")
          )
-         Future { okSycedPrefsResponse(syncedPrefs) }
+         Future.successful { okSycedPrefsResponse(syncedPrefs) }
        case Success(None) =>
          logger.debug("No articles found")
-         Future { emptyArticlesResponse  }
+         Future.successful { emptyArticlesResponse  }
        case Failure(ex) =>
          logger.debug("Error trying to retrieve saved articles")
          ex match {

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -2,7 +2,7 @@ package com.gu.sfl.controller
 
 import com.gu.sfl.lambda.LambdaResponse
 import com.gu.sfl.lib.Jackson.mapper
-import com.gu.sfl.model.{SavedArticles, SyncedPrefs, SyncedPrefsResponse}
+import com.gu.sfl.model.{SavedArticles, SavedArticlesResponse, SyncedPrefs, SyncedPrefsResponse}
 import com.gu.sfl.util.StatusCodes
 
 trait SaveForLaterController {
@@ -13,5 +13,6 @@ trait SaveForLaterController {
   val serverErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Server error."))
   val accessDenied = LambdaResponse(StatusCodes.forbidden, Some("Access denied"))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
-  def okSavedArticlesResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
+  def okSycedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
+  def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
 }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -13,6 +13,6 @@ trait SaveForLaterController {
   val serverErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Server error."))
   val accessDenied = LambdaResponse(StatusCodes.forbidden, Some("Access denied"))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
-  def okSycedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
+  def okSyncedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
 }

--- a/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
+++ b/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
@@ -38,7 +38,7 @@ case class ApiGatewayLambdaRequest(
 case class ApiGatewayLambdaResponse (
     statusCode: Int,
     body: Option[String] = None,
-    headers: Map[String, String] = Map("Content-Type" -> "application/json", "cache-control" -> "no-cache"),
+    headers: Map[String, String] = Map("Content-Type" -> "application/json; charset=UTF-8", "cache-control" -> "max-age=0")
 )
 
 
@@ -60,7 +60,8 @@ object LambdaResponse extends Base64Utils {
 case class LambdaResponse(
   statusCode: Int,
   maybeBody: Option[String],
-  headers: Map[String, String] = Map("Content-Type" -> "application/json"))
+  headers: Map[String, String] = Map("Content-Type" -> "application/json; charset=UTF-8", "cache-control" -> "max-age=0")
+)
 
 
 trait LambdaApiGateway {

--- a/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -11,18 +11,18 @@ import scala.util.{Failure, Success, Try}
 case class SavedArticlesMergerConfig(maxSavedArticlesLimit: Int)
 
 trait SavedArticlesMerger {
-  def updateWithRetryAndMerge(userId: String, savedArticles: SavedArticles): Try[Option[SyncedPrefs]]
+  def updateWithRetryAndMerge(userId: String, savedArticles: SavedArticles): Try[Option[SavedArticles]]
 }
 
 class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConfig, savedArticlesPersistence: SavedArticlesPersistence) extends SavedArticlesMerger with Logging {
 
   val maxSavedArticlesLimit: Int = savedArticlesMergerConfig.maxSavedArticlesLimit
 
-  private def persistMergedArticles(userId: String, articles: SavedArticles)( persistOperation: (String, SavedArticles) => Try[Option[SavedArticles]] ): Try[Option[SyncedPrefs]] =
+  private def persistMergedArticles(userId: String, articles: SavedArticles)( persistOperation: (String, SavedArticles) => Try[Option[SavedArticles]] ): Try[Option[SavedArticles]] =
      persistOperation(userId, articles) match {
         case Success(Some(articles)) =>
           logger.debug(s"success persisting articles for ${userId}")
-          Success(Some(SyncedPrefs(userId, Some(articles))))
+          Success(Some(articles))
         case Failure(e) =>
           logger.debug(s"Error persisting articles for ${userId}. Error: ${e.getMessage}")
           Failure(SavedArticleMergeError("Could not update articles"))
@@ -30,7 +30,7 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
 
 
 
-  override def updateWithRetryAndMerge(userId: String, savedArticles: SavedArticles): Try[Option[SyncedPrefs]] = {
+  override def updateWithRetryAndMerge(userId: String, savedArticles: SavedArticles): Try[Option[SavedArticles]] = {
 
     if( savedArticles.articles.lengthCompare(maxSavedArticlesLimit) > 0 ){
       logger.debug(s"User $userId tried to save ${savedArticles.articles.length} articles. Limit is ${maxSavedArticlesLimit}.")

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -46,7 +46,7 @@ object SavedArticles {
 
 case class SavedArticles(version: String, articles: List[SavedArticle]) extends SyncedPrefsData {
   override def advanceVersion: SavedArticles = copy(version = nextVersion)
-  def ordered: SavedArticles = copy(articles = articles.sorted)
+  def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
 }
 
 object SavedArticleDateSerializer {

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -22,6 +22,8 @@ case class SavedArticle(id: String, shortUrl: String, date: LocalDateTime, read:
 
 case class SyncedPrefsResponse(status: String, syncedPrefs: SyncedPrefs)
 
+case class SavedArticlesResponse(status: String, savedArticles: SavedArticles)
+
 /*This is cribbed from the current identity model:  https://github.com/guardian/identity/blob/master/identity-model/src/main/scala/com/gu/identity/model/Model.scala
   This service was designed to sync various categories of data for a signed in user of which saved articles were one flavour - hence synced prefs. Because we need to preserve integrity with
   existing clients (ie apps) we need to maintain this model in order to render the same json

--- a/src/main/scala/com/gu/sfl/persisitence/SavedArticlesPersistence.scala
+++ b/src/main/scala/com/gu/sfl/persisitence/SavedArticlesPersistence.scala
@@ -60,7 +60,7 @@ class SavedArticlesPersistenceImpl(persistanceConfig: PersistanceConfig) extends
     exec(client)(table.put(DynamoSavedArticles(userId, savedArticles))) match {
       case Some(Right(articles)) =>
         logger.debug("Succcesfully saved articles")
-        Success(Some(articles))
+        Success(Some(articles.ordered))
       case Some(Left(error)) =>
         val exception = new IllegalArgumentException(s"$error")
         logger.debug(s"Exception Thrown saving articles:", exception)
@@ -80,7 +80,7 @@ class SavedArticlesPersistenceImpl(persistanceConfig: PersistanceConfig) extends
     ) match {
         case Right(articles) =>
           logger.debug("Updated articles")
-          Success(Some(articles))
+          Success(Some(articles.ordered))
         case Left(error) =>
           val ex = new IllegalStateException(s"${error}")
           logger.error(s"Error updating articles for userId ${userId}: ${ex.getMessage} ")

--- a/src/main/scala/com/gu/sfl/persisitence/SavedArticlesPersistence.scala
+++ b/src/main/scala/com/gu/sfl/persisitence/SavedArticlesPersistence.scala
@@ -44,7 +44,7 @@ class SavedArticlesPersistenceImpl(persistanceConfig: PersistanceConfig) extends
     exec(client)(table.get('userId -> userId)) match {
       case Some(Right(sa)) =>
         logger.debug(s"Retrieved articles for: $userId")
-        Success(Some(sa))
+        Success(Some(sa.ordered))
       case Some(Left(error)) =>
         val ex = new IllegalArgumentException(s"$error")
         logger.debug(s"Error retrieving articles", ex)

--- a/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -10,12 +10,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait UpdateSavedArticles {
-  def save(headers: Map[String, String], savedArticles: SavedArticles) : Future[Option[SyncedPrefs]]
+  def save(headers: Map[String, String], savedArticles: SavedArticles) : Future[Option[SavedArticles]]
 }
 
 class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMerger: SavedArticlesMerger)(implicit executionContext: ExecutionContext) extends UpdateSavedArticles with Logging with AuthHeaderParser {
 
-  override def save(headers: Map[String, String], savedArticles: SavedArticles): Future[Option[SyncedPrefs]] = {
+  override def save(headers: Map[String, String], savedArticles: SavedArticles): Future[Option[SavedArticles]] = {
     (for {
       identityHeaders <- getIdentityHeaders(headers)
     } yield {

--- a/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
+++ b/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
@@ -30,7 +30,7 @@ class ArticleMergeSpecification extends Specification with Mockito  {
 
     "saves the articles if the user does not currently have any articles saved" in new Setup {
       val responseArticles = Success(Some(savedArticles.advanceVersion))
-      val expectedMergeResponse = Success(Some(SyncedPrefs(userId, Some(savedArticles.advanceVersion))))
+      val expectedMergeResponse = Success(Some(savedArticles.advanceVersion))
 
       savedArticlesPersistence.read(userId) returns (Success(None))
       savedArticlesPersistence.write(userId, savedArticles) returns (responseArticles)
@@ -44,7 +44,7 @@ class ArticleMergeSpecification extends Specification with Mockito  {
 
     "will update the the users' saved articles if there is no conflict" in new Setup {
       val responseArticles = Success(Some(savedArticles2.advanceVersion))
-      val expectedMergeResponse = Success(Some(SyncedPrefs(userId, Some(savedArticles2.advanceVersion))))
+      val expectedMergeResponse = Success(Some(savedArticles2.advanceVersion))
 
       savedArticlesPersistence.read(userId) returns(Success(Some(savedArticles)))
       savedArticlesPersistence.update(argThat(===(userId)), argThat(===(savedArticles2))) returns(responseArticles)
@@ -66,7 +66,7 @@ class ArticleMergeSpecification extends Specification with Mockito  {
       saved mustEqual(Failure(MaxSavedArticleTransgressionError(s"Tried to save more than $articleSaveLimit articles.")))
     }
 
-    "failure to get current articles throws the correct exceptiob" in new Setup {
+    "failure to get current articles throws the correct exception" in new Setup {
       savedArticlesPersistence.read(userId) returns (Failure(new IllegalStateException("Bad, bad, bad")))
       val saved = savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles)
       there was one(savedArticlesPersistence).read(argThat(===(userId)))

--- a/src/test/scala/com/gu/sfl/savedarticles/UpdateSavedArticlesSpec.scala
+++ b/src/test/scala/com/gu/sfl/savedarticles/UpdateSavedArticlesSpec.scala
@@ -104,7 +104,7 @@ class UpdateSavedArticlesSpec extends Specification with ThrownMessages with Moc
     protected val userId = "1234"
 
     val savedArticles = SavedArticles(userId, List(articleOne, articleTwo))
-    val updatedSavedArticles = SyncedPrefs(userId, Some(SavedArticles(userId, List(articleOne, articleTwo, articleThree))))
+    val updatedSavedArticles = SavedArticles(userId, List(articleOne, articleTwo, articleThree))
 
     val identityService = mock[IdentityService]
     val articlesMerger = mock[SavedArticlesMerger]


### PR DESCRIPTION
Fixes the json response to updating saved articles so that it matches that currently provided by id.guardianapis.com, We post to /syncedPrefs/me/savedArtices. we GET from /syncedPrefs/me and the generated json needs to reflect this, MY BAD

Also changes the response headers so that they match those currentty live.