### PR TITLE
Fix user not found error

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -22,11 +22,11 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
          logger.debug("No articles found")
          Future.successful { emptyArticlesResponse  }
        case Failure(ex) =>
-         logger.error("Error trying to retrieve saved articles")
+         logger.error(s"Error trying to retrieve saved articles: ${ex.getMessage}")
          ex match {
            case e: IdentityServiceException => Future.successful( identityErrorResponse )
            case e: MissingAccessTokenException => Future.successful( missingAccessTokenResponse )
-           case e: UserNotFoundException => Future.successful(emptyArticlesResponse)
+           case e: UserNotFoundException => Future.successful(missingUserResponse)
            case _ => Future.successful(serverErrorResponse )
          }
      }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -2,11 +2,11 @@ package com.gu.sfl.controller
 
 import com.gu.sfl.lambda.LambdaResponse
 import com.gu.sfl.lib.Jackson.mapper
-import com.gu.sfl.model.{SavedArticles, SavedArticlesResponse, SyncedPrefs, SyncedPrefsResponse}
+import com.gu.sfl.model._
 import com.gu.sfl.util.StatusCodes
 
 trait SaveForLaterController {
-  val missingUserResponse = LambdaResponse(StatusCodes.badRequest, Some("Could not find a user "))
+  val missingUserResponse = LambdaResponse(StatusCodes.forbidden, Some(mapper.writeValueAsString(List(Error("Access Denied", "Access Denied")))))
   val maximumSavedArticlesErrorResponse = LambdaResponse(StatusCodes.badRequest, Some("Maximum saved articles exceeded."))
   val missingAccessTokenResponse = LambdaResponse(StatusCodes.badRequest, Some("could not find an access token."))
   val identityErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Could not retrieve user id."))

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -6,7 +6,7 @@ import com.gu.sfl.model._
 import com.gu.sfl.util.StatusCodes
 
 trait SaveForLaterController {
-  val missingUserResponse = LambdaResponse(StatusCodes.forbidden, Some(mapper.writeValueAsString(List(Error("Access Denied", "Access Denied")))))
+  val missingUserResponse = LambdaResponse(StatusCodes.forbidden, Some(mapper.writeValueAsString(ErrorResponse(List(Error("Access Denied", "Access Denied"))))))
   val maximumSavedArticlesErrorResponse = LambdaResponse(StatusCodes.badRequest, Some("Maximum saved articles exceeded."))
   val missingAccessTokenResponse = LambdaResponse(StatusCodes.badRequest, Some("could not find an access token."))
   val identityErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Could not retrieve user id."))

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -49,6 +49,8 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
 }
 
+case class Error(message: String, description)
+
 object SavedArticleDateSerializer {
   val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
 }

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -49,6 +49,8 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
 }
 
+case class ErrorResponse(errors: List[Error])
+
 case class Error(message: String, description: String)
 
 object SavedArticleDateSerializer {

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -49,7 +49,7 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
 }
 
-case class Error(message: String, description)
+case class Error(message: String, description: String)
 
 object SavedArticleDateSerializer {
   val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")


### PR DESCRIPTION
This returns the same json as the previous service. Ie 

```{"errors":[{"message":"Access Denied","description":"Access Denied"}]}```

Ie here: https://github.com/guardian/identity/blob/master/identity-synced-prefs/src/main/scala/com/gu/identity/api/servlet/SyncedPrefsServlet.scala#L93