### PR TITLE
Max articles error

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -43,7 +43,7 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
             case i: IdentityServiceException => Future.successful( identityErrorResponse )
             case m: MissingAccessTokenException => Future.successful(missingAccessTokenResponse )
             case u: UserNotFoundException => Future.successful(missingUserResponse)
-            case m: MaxSavedArticleTransgressionError => Future.successful(maximumSavedArticlesErrorResponse)
+            case m: MaxSavedArticleTransgressionError => Future.successful(maximumSavedArticlesErrorResponse(m))
             case _ => Future.successful( serverErrorResponse )
           }
      }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -7,12 +7,12 @@ import com.gu.sfl.util.StatusCodes
 
 trait SaveForLaterController {
   val missingUserResponse = LambdaResponse(StatusCodes.forbidden, Some(mapper.writeValueAsString(ErrorResponse(List(Error("Access Denied", "Access Denied"))))))
-  val maximumSavedArticlesErrorResponse = LambdaResponse(StatusCodes.badRequest, Some("Maximum saved articles exceeded."))
   val missingAccessTokenResponse = LambdaResponse(StatusCodes.badRequest, Some("could not find an access token."))
   val identityErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Could not retrieve user id."))
   val serverErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Server error."))
   val accessDenied = LambdaResponse(StatusCodes.forbidden, Some("Access denied"))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
+  def maximumSavedArticlesErrorResponse(exception: Exception) = LambdaResponse(StatusCodes.entityToLarge, Some(mapper.writeValueAsString(ErrorResponse(List(Error("Payload too large", exception.getMessage))))))
   def okSyncedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
 }

--- a/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -34,7 +34,8 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
 
     if( savedArticles.articles.lengthCompare(maxSavedArticlesLimit) > 0 ){
       logger.debug(s"User $userId tried to save ${savedArticles.articles.length} articles. Limit is ${maxSavedArticlesLimit}.")
-      Failure(MaxSavedArticleTransgressionError(s"Tried to save more than $maxSavedArticlesLimit articles.") )
+      val errorMsg = s"The limit on number of saved articles is $maxSavedArticlesLimit"
+      Failure(MaxSavedArticleTransgressionError(errorMsg))
     } else {
       savedArticlesPersistence.read(userId) match {
         case Success(Some(currentArticles)) if currentArticles.version == savedArticles.version =>

--- a/src/main/scala/com/gu/sfl/util/StatusCodes.scala
+++ b/src/main/scala/com/gu/sfl/util/StatusCodes.scala
@@ -5,5 +5,5 @@ object StatusCodes {
   val ok: Int = 200
   val badRequest: Int = 400
   val forbidden: Int = 403
-  val entityToLarge = 413
+  val entityTooLarge = 413
 }

--- a/src/main/scala/com/gu/sfl/util/StatusCodes.scala
+++ b/src/main/scala/com/gu/sfl/util/StatusCodes.scala
@@ -5,5 +5,5 @@ object StatusCodes {
   val ok: Int = 200
   val badRequest: Int = 400
   val forbidden: Int = 403
-
+  val entityToLarge = 413
 }

--- a/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
+++ b/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
@@ -57,13 +57,13 @@ class ArticleMergeSpecification extends Specification with Mockito  {
     
 
     "will not try to merge a list of articles with a length greater than the saved article limit" in new Setup {
-      private val articleSaveLimit = 2
-      override val savedArticlesMerger = new SavedArticlesMergerImpl(SavedArticlesMergerConfig(articleSaveLimit), savedArticlesPersistence)
+      private val maxSavedArticlesLimit = 2
+      override val savedArticlesMerger = new SavedArticlesMergerImpl(SavedArticlesMergerConfig(maxSavedArticlesLimit), savedArticlesPersistence)
       val saved = savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles2)
       there were no (savedArticlesPersistence).read(argThat(===(userId)))
       there were no (savedArticlesPersistence).write(any[String](), any[SavedArticles]())
       there were no (savedArticlesPersistence).update(any[String](), any[SavedArticles]())
-      saved mustEqual(Failure(MaxSavedArticleTransgressionError(s"Tried to save more than $articleSaveLimit articles.")))
+      saved mustEqual(Failure(MaxSavedArticleTransgressionError(s"The limit on number of saved articles is $maxSavedArticlesLimit")))
     }
 
     "failure to get current articles throws the correct exception" in new Setup {


### PR DESCRIPTION
Corrects the error response returned when the max number of articles is exceeded to:

{"errors":[{"message":"Payload too large","description":"The limit on number of saved articles is 1000"}]}

As per https://github.com/guardian/identity/blob/master/identity-model/src/main/scala/com/gu/identity/model/Errors.scala#L67