### PR TITLE
return an empty ok response when the user has no saved articles

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -18,9 +18,6 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
             logger.debug(s"Returning found: ${sp.articles.size} articles")
          )
          Future.successful { okSyncedPrefsResponse(syncedPrefs) }
-       case Success(None) =>
-         logger.debug("No articles found")
-         Future.successful { emptyArticlesResponse  }
        case Failure(ex) =>
          logger.error(s"Error trying to retrieve saved articles: ${ex.getMessage}")
          ex match {

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -42,6 +42,7 @@ sealed trait SyncedPrefsData {
 object SavedArticles {
   def nextVersion() = Instant.now().toEpochMilli.toString
   def apply(articles: List[SavedArticle]) : SavedArticles = SavedArticles(nextVersion(), articles)
+  val empty = SavedArticles("1", List.empty)
 }
 
 case class SavedArticles(version: String, articles: List[SavedArticle]) extends SyncedPrefsData {

--- a/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
@@ -18,6 +18,7 @@ class FetchSavedArticlesImpl(identityService: IdentityService, savedArticlesPers
 
   private def wrapSavedArticles(userId: String, maybeSavedArticles: Try[Option[SavedArticles]]) : Try[Option[SyncedPrefs]] = maybeSavedArticles match {
     case Success(Some(articles)) => Success(Some(SyncedPrefs(userId, Some(articles))))
+    case Success(_) => Success(Some(SyncedPrefs(userId, Some(SavedArticles.empty))))
     case _ => Failure(RetrieveSavedArticlesError("Could not update articles"))
   }
 

--- a/src/test/scala/com/gu/sfl/savedarticles/FetchSavedcArticlesSpec.scala
+++ b/src/test/scala/com/gu/sfl/savedarticles/FetchSavedcArticlesSpec.scala
@@ -56,12 +56,20 @@ class FetchSavedcArticlesSpec extends Specification with ThrownMessages with Moc
     Await.result(savedArticlesFuture, Duration.Inf) mustEqual(Some(SyncedPrefs(userId, Some(savedArticles))))
   }
 
-  "ehen the user has no articles then the response contains an empty list" in new SetupWithUserId {
+  "when the user has no articles then the response contains an empty list" in new SetupWithUserId {
     val emptyArticles = SavedArticles("123454", List.empty)
     savedArticlesPersistence.read(argThat(===(userId))) returns(Success(Some(emptyArticles)))
     val savedArticlesFuture = fetchSavedArticlesImpl.retrieveForUser(requestHeaders)
     Await.result(savedArticlesFuture, Duration.Inf) mustEqual(Some(SyncedPrefs(userId, Some(emptyArticles))))
   }
+
+  "when the user has never saved any articles the response contains an empty list" in new SetupWithUserId {
+     val emptyArticles = SavedArticles("1", List.empty)
+     savedArticlesPersistence.read(argThat(===(userId))).returns(Success(None))
+     val savedArticlesFuture = fetchSavedArticlesImpl.retrieveForUser(requestHeaders)
+     Await.result(savedArticlesFuture, Duration.Inf) mustEqual(Some(SyncedPrefs(userId, Some(emptyArticles))))
+  }
+
 
   "when the identity api does not return a user id then no attemp is made to retrieve persisted articles" in new SeupWithoutUserId  {
     fetchSavedArticlesImpl.retrieveForUser(requestHeaders)


### PR DESCRIPTION
This fixes the vast majority of the errors seen here - which are coming up as 5xx errors when the user has no articles save: 
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=SaveForLater

Here we respond instead with a 200 and an empty response