### PR TITLE
give error responses a status

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -24,7 +24,7 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
            case e: IdentityServiceException => Future.successful( identityErrorResponse )
            case e: MissingAccessTokenException => Future.successful( missingAccessTokenResponse )
            case e: UserNotFoundException => Future.successful(missingUserResponse)
-           case _ => Future.successful(serverErrorResponse(ex.getMessage) )
+           case _ => Future.successful(serverErrorResponse("Error fetching articles") )
          }
      }
      futureResponse

--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -24,7 +24,7 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
            case e: IdentityServiceException => Future.successful( identityErrorResponse )
            case e: MissingAccessTokenException => Future.successful( missingAccessTokenResponse )
            case e: UserNotFoundException => Future.successful(missingUserResponse)
-           case _ => Future.successful(serverErrorResponse )
+           case _ => Future.successful(serverErrorResponse(ex.getMessage) )
          }
      }
      futureResponse

--- a/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -44,7 +44,7 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
             case m: MissingAccessTokenException => Future.successful(missingAccessTokenResponse )
             case u: UserNotFoundException => Future.successful(missingUserResponse)
             case m: MaxSavedArticleTransgressionError => Future.successful(maximumSavedArticlesErrorResponse(m))
-            case _ => Future.successful( serverErrorResponse(t.getMessage) )
+            case _ => Future.successful( serverErrorResponse("Error updating articles") )
           }
      }
   }

--- a/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -44,7 +44,7 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
             case m: MissingAccessTokenException => Future.successful(missingAccessTokenResponse )
             case u: UserNotFoundException => Future.successful(missingUserResponse)
             case m: MaxSavedArticleTransgressionError => Future.successful(maximumSavedArticlesErrorResponse(m))
-            case _ => Future.successful( serverErrorResponse )
+            case _ => Future.successful( serverErrorResponse(t.getMessage) )
           }
      }
   }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -6,13 +6,17 @@ import com.gu.sfl.model._
 import com.gu.sfl.util.StatusCodes
 
 trait SaveForLaterController {
-  val missingUserResponse = LambdaResponse(StatusCodes.forbidden, Some(mapper.writeValueAsString(ErrorResponse(List(Error("Access Denied", "Access Denied"))))))
-  val missingAccessTokenResponse = LambdaResponse(StatusCodes.badRequest, Some("could not find an access token."))
-  val identityErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Could not retrieve user id."))
-  val serverErrorResponse = LambdaResponse(StatusCodes.internalServerError, Some("Server error."))
-  val accessDenied = LambdaResponse(StatusCodes.forbidden, Some("Access denied"))
+
+
+  def lambdaErrorResponse(statusCode:Int, errors: List[Error]) = LambdaResponse(statusCode, Some(mapper.writeValueAsString(ErrorResponse(errors = errors))))
+
+  val missingUserResponse = lambdaErrorResponse(StatusCodes.forbidden, List(Error("Access Denied", "Access Denied")))
+  val missingAccessTokenResponse = lambdaErrorResponse(StatusCodes.forbidden, List(Error("Access denied", "could not find an access token.")))
+  val identityErrorResponse = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Access denied","Could not retrieve user id.")))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
-  def maximumSavedArticlesErrorResponse(exception: Exception) = LambdaResponse(StatusCodes.entityTooLarge, Some(mapper.writeValueAsString(ErrorResponse(List(Error("Payload too large", exception.getMessage))))))
+
   def okSyncedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
+  def serverErrorResponse(message: String) = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Server error.", message)))
+  def maximumSavedArticlesErrorResponse(exception: Exception) = lambdaErrorResponse(StatusCodes.entityTooLarge, (List(Error("Payload too large", exception.getMessage))))
 }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -15,8 +15,8 @@ trait SaveForLaterController {
   val identityErrorResponse = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Access denied","Could not retrieve user id.")))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
 
+  def maximumSavedArticlesErrorResponse(exception: Exception) = lambdaErrorResponse(StatusCodes.entityTooLarge, (List(Error("Payload too large", exception.getMessage))))
   def okSyncedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
   def serverErrorResponse(message: String) = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Server error.", message)))
-  def maximumSavedArticlesErrorResponse(exception: Exception) = lambdaErrorResponse(StatusCodes.entityTooLarge, (List(Error("Payload too large", exception.getMessage))))
 }

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -50,7 +50,7 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
 }
 
-case class ErrorResponse(errors: List[Error])
+case class ErrorResponse(status: String = "error", errors: List[Error])
 
 case class Error(message: String, description: String)
 


### PR DESCRIPTION
Correctly formats all error responses so that they match those previously served by the identity api: The format should be: 

```{"status":"error", "errors":[{"message":"xMessage","description":"xDescription"}]}```