### PR TITLE
Refactor error handling

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -20,9 +20,9 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
             logger.debug(s"Returning found: ${sp.articles.size} articles")
          )
          okSyncedPrefsResponse(syncedPrefs)
-       case Left(ex) =>
-         logger.error(s"Error trying to retrieve saved articles: ${ex.message}")
-         processErrorResponse(ex) {
+       case Left(error) =>
+         logger.error(s"Error trying to retrieve saved articles: ${error.message}")
+         processErrorResponse(error) {
            case e: IdentityServiceError =>  identityErrorResponse
            case e: MissingAccessTokenError => missingAccessTokenResponse
            case e: UserNotFoundError => missingUserResponse

--- a/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/FetchArticlesController.scala
@@ -3,7 +3,7 @@ package com.gu.sfl.controller
 import com.gu.sfl.lambda.{LambdaRequest, LambdaResponse}
 import com.gu.sfl.savedarticles.FetchSavedArticles
 import com.gu.sfl.Logging
-import com.gu.sfl.exception.{IdentityServiceException, MissingAccessTokenException, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityServiceError, MissingAccessTokenError, UserNotFoundError}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -23,9 +23,9 @@ class FetchArticlesController(fetchSavedArticles: FetchSavedArticles)(implicit e
        case Left(ex) =>
          logger.error(s"Error trying to retrieve saved articles: ${ex.message}")
          processErrorResponse(ex) {
-           case e: IdentityServiceException =>  identityErrorResponse
-           case e: MissingAccessTokenException => missingAccessTokenResponse
-           case e: UserNotFoundException => missingUserResponse
+           case e: IdentityServiceError =>  identityErrorResponse
+           case e: MissingAccessTokenError => missingAccessTokenResponse
+           case e: UserNotFoundError => missingUserResponse
          }
      }
      futureResponse

--- a/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.controller
 
-import com.gu.sfl.exception.{IdentityServiceException, MaxSavedArticleTransgressionError, MissingAccessTokenException, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityServiceError, MaxSavedArticleTransgressionError, MissingAccessTokenError, UserNotFoundError}
 import com.gu.sfl.lambda.{LambdaRequest, LambdaResponse}
 import com.gu.sfl.lib.Base64Utils
 import com.gu.sfl.lib.Jackson._
@@ -39,9 +39,9 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
        case Left(error) =>
           logger.error(s"Error saving articles: ${error.message}")
           processErrorResponse(error) {
-            case i: IdentityServiceException =>  identityErrorResponse
-            case m: MissingAccessTokenException => missingAccessTokenResponse
-            case u: UserNotFoundException => missingUserResponse
+            case i: IdentityServiceError =>  identityErrorResponse
+            case m: MissingAccessTokenError => missingAccessTokenResponse
+            case u: UserNotFoundError => missingUserResponse
             case m: MaxSavedArticleTransgressionError => maximumSavedArticlesErrorResponse(m.message)
           }
      }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -1,12 +1,17 @@
 package com.gu.sfl.controller
 
+import com.gu.sfl.Logging
+import com.gu.sfl.exception.SaveForLaterError
 import com.gu.sfl.lambda.LambdaResponse
 import com.gu.sfl.lib.Jackson.mapper
 import com.gu.sfl.model._
 import com.gu.sfl.util.StatusCodes
 
-trait SaveForLaterController {
+import scala.concurrent.Future
 
+trait SaveForLaterController extends Logging {
+
+  def defaultErrorMessage: String
 
   def lambdaErrorResponse(statusCode:Int, errors: List[Error]) = LambdaResponse(statusCode, Some(mapper.writeValueAsString(ErrorResponse(errors = errors))))
 
@@ -15,8 +20,17 @@ trait SaveForLaterController {
   val identityErrorResponse = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Access denied","Could not retrieve user id.")))
   val emptyArticlesResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticles(List.empty))))
 
-  def maximumSavedArticlesErrorResponse(exception: Exception) = lambdaErrorResponse(StatusCodes.entityTooLarge, (List(Error("Payload too large", exception.getMessage))))
+  def maximumSavedArticlesErrorResponse(message: String) = lambdaErrorResponse(StatusCodes.entityTooLarge, (List(Error("Payload too large", message))))
   def okSyncedPrefsResponse(syncedPrefs: SyncedPrefs): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SyncedPrefsResponse("ok", syncedPrefs))))
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
   def serverErrorResponse(message: String) = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Server error.", message)))
+
+  def processErrorResponse(error: SaveForLaterError)(errorResolutions: PartialFunction[SaveForLaterError, LambdaResponse] = PartialFunction.empty) : LambdaResponse = {
+    val errorResponseMaker = errorResolutions.orElse[SaveForLaterError, LambdaResponse] {
+      case _ =>
+        logger.error(s"Could not find correct response for: ${error}")
+        serverErrorResponse(defaultErrorMessage)
+    }
+    errorResponseMaker(error)
+  }
 }

--- a/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveForLaterController.scala
@@ -25,12 +25,11 @@ trait SaveForLaterController extends Logging {
   def okSavedArticlesResponse(savedArticles: SavedArticles): LambdaResponse = LambdaResponse(StatusCodes.ok, Some(mapper.writeValueAsString(SavedArticlesResponse("ok", savedArticles))))
   def serverErrorResponse(message: String) = lambdaErrorResponse(StatusCodes.internalServerError, List(Error("Server error.", message)))
 
-  def processErrorResponse(error: SaveForLaterError)(errorResolutions: PartialFunction[SaveForLaterError, LambdaResponse] = PartialFunction.empty) : LambdaResponse = {
-    val errorResponseMaker = errorResolutions.orElse[SaveForLaterError, LambdaResponse] {
-      case _ =>
-        logger.error(s"Could not find correct response for: ${error}")
-        serverErrorResponse(defaultErrorMessage)
+  def processErrorResponse(error: SaveForLaterError)(errorResolutions: PartialFunction[SaveForLaterError, LambdaResponse]) : LambdaResponse = {
+    val lift = errorResolutions.lift
+    lift(error).getOrElse {
+      logger.error(s"Could not find correct response for: ${error}")
+      serverErrorResponse(defaultErrorMessage)
     }
-    errorResponseMaker(error)
   }
 }

--- a/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
+++ b/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
@@ -4,9 +4,9 @@ sealed trait SaveForLaterError {
   def message: String
 }
 
-case class MissingAccessTokenException(message: String) extends SaveForLaterError
-case class UserNotFoundException(message: String) extends SaveForLaterError
-case class IdentityServiceException(message: String) extends SaveForLaterError
+case class MissingAccessTokenError(message: String) extends SaveForLaterError
+case class UserNotFoundError(message: String) extends SaveForLaterError
+case class IdentityServiceError(message: String) extends SaveForLaterError
 case class SavedArticleMergeError(message: String) extends  SaveForLaterError
 case class MaxSavedArticleTransgressionError(message: String) extends SaveForLaterError
 case class RetrieveSavedArticlesError(message: String) extends SaveForLaterError

--- a/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
+++ b/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
@@ -1,13 +1,15 @@
 package com.gu.sfl.exception
 
 sealed trait SaveForLaterError {
-  self: Throwable =>
+  def message: String
 }
 
-case class MissingAccessTokenException(message: String) extends Exception(message) with SaveForLaterError
-case class UserNotFoundException(message: String) extends Exception(message) with SaveForLaterError
-case class IdentityServiceException(message: String) extends Exception(message) with SaveForLaterError
-case class SavedArticleMergeError(message: String) extends  Exception(message) with SaveForLaterError
-case class MaxSavedArticleTransgressionError(message: String) extends Exception(message) with SaveForLaterError
-case class IdentityApiRequestError(message: String) extends Exception(message) with SaveForLaterError
-case class RetrieveSavedArticlesError(message: String) extends Exception(message) with SaveForLaterError
+case class MissingAccessTokenException(message: String) extends SaveForLaterError
+case class UserNotFoundException(message: String) extends SaveForLaterError
+case class IdentityServiceException(message: String) extends SaveForLaterError
+case class SavedArticleMergeError(message: String) extends  SaveForLaterError
+case class MaxSavedArticleTransgressionError(message: String) extends SaveForLaterError
+case class RetrieveSavedArticlesError(message: String) extends SaveForLaterError
+
+
+case class IdentityApiRequestError(message: String) extends Exception(message)

--- a/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
@@ -32,14 +32,14 @@ class FetchSavedArticlesImpl(identityService: IdentityService, savedArticlesPers
           Future.successful(wrapSavedArticles(userId, savedArticlesPersistence.read(userId)))
         case Success(_) =>
           logger.debug(s"no user found for AccessToken ${identityHeaders.accessToken}")
-          Future.successful(Left(new UserNotFoundException("Could not retrieve a user id")))
+          Future.successful(Left(new UserNotFoundError("Could not retrieve a user id")))
         case Failure(_) =>
           logger.debug(s"Error retrieving userId for: token: ${identityHeaders.accessToken}")
-          Future.successful(Left(new IdentityServiceException("Could not get a response from the id api")))
+          Future.successful(Left(new IdentityServiceError("Could not get a response from the id api")))
       }
     }).getOrElse{
       logger.debug(s"Could not retrieve identity headers")
-      Future.successful(Left(MissingAccessTokenException("No access token on request")))
+      Future.successful(Left(MissingAccessTokenError("No access token on request")))
     }
   }
 }

--- a/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/FetchSavedArticles.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.savedarticles
 
-import com.gu.sfl.exception.{IdentityServiceException, MissingAccessTokenException, RetrieveSavedArticlesError, UserNotFoundException}
+import com.gu.sfl.exception._
 import com.gu.sfl.identity.IdentityService
 import com.gu.sfl.lib.AuthHeaderParser
 import com.gu.sfl.model._
@@ -11,35 +11,35 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 trait FetchSavedArticles {
-    def retrieveForUser(headers: Map[String, String]) : Future[Option[SyncedPrefs]]
+    def retrieveForUser(headers: Map[String, String]) : Future[Either[SaveForLaterError, SyncedPrefs]]
 }
 
 class FetchSavedArticlesImpl(identityService: IdentityService, savedArticlesPersistence: SavedArticlesPersistence)(implicit executionContext: ExecutionContext) extends FetchSavedArticles with Logging with AuthHeaderParser{
 
-  private def wrapSavedArticles(userId: String, maybeSavedArticles: Try[Option[SavedArticles]]) : Try[Option[SyncedPrefs]] = maybeSavedArticles match {
-    case Success(Some(articles)) => Success(Some(SyncedPrefs(userId, Some(articles))))
-    case Success(_) => Success(Some(SyncedPrefs(userId, Some(SavedArticles.empty))))
-    case _ => Failure(RetrieveSavedArticlesError("Could not update articles"))
+  private def wrapSavedArticles(userId: String, maybeSavedArticles: Try[Option[SavedArticles]]) : Either[SaveForLaterError, SyncedPrefs] = maybeSavedArticles match {
+    case Success(Some(articles)) => Right(SyncedPrefs(userId, Some(articles)))
+    case Success(_) => Right(SyncedPrefs(userId, Some(SavedArticles.empty)))
+    case _ => Left(RetrieveSavedArticlesError("Could not update articles"))
   }
 
-  override def retrieveForUser(headers: Map[String, String]): Future[Option[SyncedPrefs]] = {
+  override def retrieveForUser(headers: Map[String, String]): Future[Either[SaveForLaterError, SyncedPrefs]] = {
     (for {
       identityHeaders <- getIdentityHeaders(headers)
     } yield {
       identityService.userFromRequest(identityHeaders).transformWith{
         case Success(Some(userId)) =>
           logger.info(s"Got user id ${userId} from identity")
-          Future.fromTry(wrapSavedArticles(userId, savedArticlesPersistence.read(userId)))
+          Future.successful(wrapSavedArticles(userId, savedArticlesPersistence.read(userId)))
         case Success(_) =>
           logger.debug(s"no user found for AccessToken ${identityHeaders.accessToken}")
-          Future.failed(new UserNotFoundException("Could not retrieve a user id"))
+          Future.successful(Left(new UserNotFoundException("Could not retrieve a user id")))
         case Failure(_) =>
           logger.debug(s"Error retrieving userId for: token: ${identityHeaders.accessToken}")
-          Future.failed(new IdentityServiceException("Could not get a response from the id api"))
+          Future.successful(Left(new IdentityServiceException("Could not get a response from the id api")))
       }
     }).getOrElse{
       logger.debug(s"Could not retrieve identity headers")
-      Future.failed(MissingAccessTokenException("No access token on request"))
+      Future.successful(Left(MissingAccessTokenException("No access token on request")))
     }
   }
 }

--- a/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.savedarticles
 
-import com.gu.sfl.exception.{IdentityServiceException, MissingAccessTokenException, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityServiceException, MissingAccessTokenException, SaveForLaterError, UserNotFoundException}
 import com.gu.sfl.identity.IdentityService
 import com.gu.sfl.lib.{AuthHeaderParser, SavedArticlesMerger}
 import com.gu.sfl.model.{SavedArticles, SyncedPrefs}
@@ -10,26 +10,26 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait UpdateSavedArticles {
-  def save(headers: Map[String, String], savedArticles: SavedArticles) : Future[Option[SavedArticles]]
+  def save(headers: Map[String, String], savedArticles: SavedArticles) : Future[Either[SaveForLaterError, SavedArticles]]
 }
 
 class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMerger: SavedArticlesMerger)(implicit executionContext: ExecutionContext) extends UpdateSavedArticles with Logging with AuthHeaderParser {
 
-  override def save(headers: Map[String, String], savedArticles: SavedArticles): Future[Option[SavedArticles]] = {
+  override def save(headers: Map[String, String], savedArticles: SavedArticles): Future[Either[SaveForLaterError, SavedArticles]] = {
     (for {
       identityHeaders <- getIdentityHeaders(headers)
     } yield {
         identityService.userFromRequest(identityHeaders) transformWith {
           case Success(Some(userId)) =>
             logger.info(s"Attempting to save articles fo user: $userId")
-            Future.fromTry(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
+            Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
           case Success(_) =>
             logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")
-            Future.failed (new UserNotFoundException("Could not retrieve a user id"))
+            Future.successful(Left(new UserNotFoundException("Could not retrieve a user id")))
           case Failure(_) =>
             logger.debug(s"Error retrieving userId for: token: ${identityHeaders.accessToken}")
-            Future.failed (new IdentityServiceException("Could not retrieve a user from the id api"))
+            Future.successful(Left(new IdentityServiceException("Could not retrieve a user from the id api")))
         }
-     }).getOrElse(Future.failed(new MissingAccessTokenException("No access token on request")))
+     }).getOrElse(Future.successful(Left(new MissingAccessTokenException("No access token on request"))))
   }
 }

--- a/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -19,7 +19,8 @@ class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMer
     (for {
       identityHeaders <- getIdentityHeaders(headers)
     } yield {
-        identityService.userFromRequest(identityHeaders) transformWith {
+      val eventualMaybeString = identityService.userFromRequest(identityHeaders)
+      eventualMaybeString transformWith {
           case Success(Some(userId)) =>
             logger.info(s"Attempting to save articles fo user: $userId")
             Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))

--- a/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.savedarticles
 
-import com.gu.sfl.exception.{IdentityServiceException, MissingAccessTokenException, SaveForLaterError, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityServiceError, MissingAccessTokenError, SaveForLaterError, UserNotFoundError}
 import com.gu.sfl.identity.IdentityService
 import com.gu.sfl.lib.{AuthHeaderParser, SavedArticlesMerger}
 import com.gu.sfl.model.{SavedArticles, SyncedPrefs}
@@ -26,11 +26,11 @@ class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMer
             Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
           case Success(_) =>
             logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")
-            Future.successful(Left(new UserNotFoundException("Could not retrieve a user id")))
+            Future.successful(Left(new UserNotFoundError("Could not retrieve a user id")))
           case Failure(_) =>
             logger.debug(s"Error retrieving userId for: token: ${identityHeaders.accessToken}")
-            Future.successful(Left(new IdentityServiceException("Could not retrieve a user from the id api")))
+            Future.successful(Left(new IdentityServiceError("Could not retrieve a user from the id api")))
         }
-     }).getOrElse(Future.successful(Left(new MissingAccessTokenException("No access token on request"))))
+     }).getOrElse(Future.successful(Left(new MissingAccessTokenError("No access token on request"))))
   }
 }

--- a/src/test/scala/com/gu/sfl/savedarticles/FetchSavedcArticlesSpec.scala
+++ b/src/test/scala/com/gu/sfl/savedarticles/FetchSavedcArticlesSpec.scala
@@ -2,7 +2,7 @@ package com.gu.sfl.savedarticles
 
 import java.time.LocalDateTime
 
-import com.gu.sfl.exception.{IdentityApiRequestError, IdentityServiceException, MissingAccessTokenException, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityApiRequestError, IdentityServiceError, MissingAccessTokenError, UserNotFoundError}
 import com.gu.sfl.identity.{IdentityHeader, IdentityService}
 import com.gu.sfl.model.{SavedArticle, SavedArticles, SyncedPrefs}
 import com.gu.sfl.persisitence.SavedArticlesPersistence
@@ -34,7 +34,7 @@ class FetchSavedcArticlesSpec extends Specification with ThrownMessages with Moc
 
     invalidResult map {
       case Left(_) => fail("No missing auth exception thrown")
-      case Right(ex) => ex mustEqual(MissingAccessTokenException("No access token on request"))
+      case Right(ex) => ex mustEqual(MissingAccessTokenError("No access token on request"))
     }
   }
 
@@ -79,7 +79,7 @@ class FetchSavedcArticlesSpec extends Specification with ThrownMessages with Moc
     val futureFetchException = Await.ready(fetchSavedArticlesImpl.retrieveForUser(requestHeaders), Duration.Inf).value.get
     futureFetchException map {
       case Right(_) => fail("No missing user errot")
-      case Left(ex) => ex mustEqual(new UserNotFoundException("Could not retrieve a user id"))
+      case Left(ex) => ex mustEqual(new UserNotFoundError("Could not retrieve a user id"))
     }
   }
 
@@ -88,7 +88,7 @@ class FetchSavedcArticlesSpec extends Specification with ThrownMessages with Moc
     val futureFetchException = Await.ready(fetchSavedArticlesImpl.retrieveForUser(requestHeaders), Duration.Inf)
     futureFetchException map {
       case Right(_) => fail("No missing user errot")
-      case Left(ex) => ex mustEqual(new IdentityServiceException("Could not get a response from the id api"))
+      case Left(ex) => ex mustEqual(new IdentityServiceError("Could not get a response from the id api"))
     }
   }
 

--- a/src/test/scala/com/gu/sfl/savedarticles/UpdateSavedArticlesSpec.scala
+++ b/src/test/scala/com/gu/sfl/savedarticles/UpdateSavedArticlesSpec.scala
@@ -2,7 +2,7 @@ package com.gu.sfl.savedarticles
 
 import java.time.LocalDateTime
 
-import com.gu.sfl.exception.{IdentityApiRequestError, IdentityServiceException, MissingAccessTokenException, UserNotFoundException}
+import com.gu.sfl.exception.{IdentityApiRequestError, IdentityServiceError, MissingAccessTokenError, UserNotFoundError}
 import com.gu.sfl.identity.{IdentityHeader, IdentityService}
 import com.gu.sfl.lib.SavedArticlesMerger
 import com.gu.sfl.model.{SavedArticle, SavedArticles, SyncedPrefs}
@@ -35,7 +35,7 @@ class UpdateSavedArticlesSpec extends Specification with ThrownMessages with Moc
 
     updateResponse map {
       case Left(_) => fail("No IOxception thrown")
-      case Right(e) => e mustEqual(MissingAccessTokenException("No access token on request"))
+      case Right(e) => e mustEqual(MissingAccessTokenError("No access token on request"))
     }
   }
 
@@ -49,7 +49,7 @@ class UpdateSavedArticlesSpec extends Specification with ThrownMessages with Moc
 
     updateResponse map {
       case Left(_) => fail("No IOxception thrown")
-      case Right(e) => e mustEqual(UserNotFoundException("Could not retrieve a user id"))
+      case Right(e) => e mustEqual(UserNotFoundError("Could not retrieve a user id"))
     }
   }
 
@@ -65,7 +65,7 @@ class UpdateSavedArticlesSpec extends Specification with ThrownMessages with Moc
 
     updateResponse map {
       case Right(_) => fail("No IOxception thrown")
-      case Left(e) => e mustEqual(IdentityServiceException("Could not retrieve a user from the id api"))
+      case Left(e) => e mustEqual(IdentityServiceError("Could not retrieve a user from the id api"))
     }
   }
 


### PR DESCRIPTION
Refactors from a Future[SavedArticles] model to a Future[Either[Error, SavedArticles] model in order to handle errors in a more robust scala like way. My bad, I did chapter 4 of the scala red book a few weeks ago and I should have known better