### PR TITLE
only persist the most recent 1000 articles

### DIFF
--- a/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.controller
 
-import com.gu.sfl.exception.{IdentityServiceError, MaxSavedArticleTransgressionError, MissingAccessTokenError, UserNotFoundError}
+import com.gu.sfl.exception.{IdentityServiceError, MissingAccessTokenError, UserNotFoundError}
 import com.gu.sfl.lambda.{LambdaRequest, LambdaResponse}
 import com.gu.sfl.lib.Base64Utils
 import com.gu.sfl.lib.Jackson._
@@ -42,7 +42,6 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
             case i: IdentityServiceError =>  identityErrorResponse
             case m: MissingAccessTokenError => missingAccessTokenResponse
             case u: UserNotFoundError => missingUserResponse
-            case m: MaxSavedArticleTransgressionError => maximumSavedArticlesErrorResponse(m.message)
           }
      }
   }

--- a/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
+++ b/src/main/scala/com/gu/sfl/exception/SaveForLaterError.scala
@@ -8,7 +8,6 @@ case class MissingAccessTokenError(message: String) extends SaveForLaterError
 case class UserNotFoundError(message: String) extends SaveForLaterError
 case class IdentityServiceError(message: String) extends SaveForLaterError
 case class SavedArticleMergeError(message: String) extends  SaveForLaterError
-case class MaxSavedArticleTransgressionError(message: String) extends SaveForLaterError
 case class RetrieveSavedArticlesError(message: String) extends SaveForLaterError
 
 

--- a/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -1,7 +1,7 @@
 package com.gu.sfl.lib
 
 import com.gu.sfl.Logging
-import com.gu.sfl.exception.{MaxSavedArticleTransgressionError, SaveForLaterError, SavedArticleMergeError}
+import com.gu.sfl.exception.{SaveForLaterError, SavedArticleMergeError}
 import com.gu.sfl.model._
 import com.gu.sfl.persisitence.SavedArticlesPersistence
 
@@ -47,6 +47,7 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
     }
   }
 
+  //This is done here for debugging puposes. To be removed when we are connfident it's no longer needed
   private def getArticlesToPersist(savedArticles: SavedArticles) : SavedArticles = {
     val deDupedArticles = savedArticles.deduped
     logger.info(s"Saving articles - Number of raw articles from client: ${savedArticles.numberOfArticles}, Dupicates removed: ${deDupedArticles.numberOfArticles} ")

--- a/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -18,43 +18,44 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
 
   val maxSavedArticlesLimit: Int = savedArticlesMergerConfig.maxSavedArticlesLimit
 
-  private def persistMergedArticles(userId: String, articles: SavedArticles)( persistOperation: (String, SavedArticles) => Try[Option[SavedArticles]] ): Either[SaveForLaterError, SavedArticles] =
-     persistOperation(userId, articles) match {
-        case Success(Some(articles)) =>
-          logger.debug(s"success persisting articles for ${userId}")
-          Right(articles)
-        case Failure(e) =>
-          logger.debug(s"Error persisting articles for ${userId}. Error: ${e.getMessage}")
-          Left(SavedArticleMergeError("Could not update articles"))
-     }
-
+  private def persistMergedArticles(userId: String, articles: SavedArticles)( persistOperation: (String, SavedArticles) => Try[Option[SavedArticles]] ): Either[SaveForLaterError, SavedArticles] = {
+    val articlesToPersist = articles.persitable(savedArticlesMergerConfig.maxSavedArticlesLimit)
+    persistOperation(userId, articlesToPersist) match {
+      case Success(Some(articles)) =>
+        logger.debug(s"success persisting articles for ${userId}")
+        Right(articles)
+      case Failure(e) =>
+        logger.debug(s"Error persisting articles for ${userId}. Error: ${e.getMessage}")
+        Left(SavedArticleMergeError("Could not update articles"))
+    }
+  }
 
 
   override def updateWithRetryAndMerge(userId: String, savedArticles: SavedArticles): Either[SaveForLaterError, SavedArticles] = {
 
-    val deDupedArticles = savedArticles.deduped
+    val articlesToPersist = getArticlesToPersist(savedArticles)
 
+    savedArticlesPersistence.read(userId) match {
+      case Success(Some(currentArticles)) if currentArticles.version == articlesToPersist.version =>
+        persistMergedArticles(userId, articlesToPersist)(savedArticlesPersistence.update)
+      case Success(Some(currentArticles)) =>
+        val articlesToSave = currentArticles.copy(articles = MergeLogic.mergeListBy(currentArticles.articles, articlesToPersist.articles)(_.id))
+       persistMergedArticles(userId, articlesToSave)(savedArticlesPersistence.update)
+      case Success(None) =>
+        persistMergedArticles(userId, articlesToPersist)(savedArticlesPersistence.write)
+      case _ => Left(SavedArticleMergeError("Could not retrieve current articles"))
+    }
+  }
+
+  private def getArticlesToPersist(savedArticles: SavedArticles) : SavedArticles = {
+    val deDupedArticles = savedArticles.deduped
     logger.info(s"Saving articles - Number of raw articles from client: ${savedArticles.numberOfArticles}, Dupicates removed: ${deDupedArticles.numberOfArticles} ")
     if (savedArticles.numberOfArticles != deDupedArticles.numberOfArticles) {
       logger.error(s"Attempt to save duplicate articles ${savedArticles.numberOfArticles}, deduped: ${deDupedArticles.numberOfArticles}")
     }
-
-    if( deDupedArticles.articles.lengthCompare(maxSavedArticlesLimit) > 0 ){
-      logger.debug(s"User $userId tried to save ${savedArticles.articles.length} articles. Limit is ${maxSavedArticlesLimit}.")
-      val errorMsg = s"The limit on number of saved articles is $maxSavedArticlesLimit"
-      Left(MaxSavedArticleTransgressionError(errorMsg))
-    } else {
-      savedArticlesPersistence.read(userId) match {
-        case Success(Some(currentArticles)) if currentArticles.version == deDupedArticles.version =>
-          persistMergedArticles(userId, deDupedArticles)(savedArticlesPersistence.update)
-        case Success(Some(currentArticles)) =>
-          val articlesToSave = currentArticles.copy(articles = MergeLogic.mergeListBy(currentArticles.articles, deDupedArticles.articles)(_.id))
-          persistMergedArticles(userId, articlesToSave)(savedArticlesPersistence.update)
-        case Success(None) =>
-          persistMergedArticles(userId, deDupedArticles)(savedArticlesPersistence.write)
-        case _ => Left(SavedArticleMergeError("Could not retrieve current articles"))
-      }
-
+    if (savedArticles.numberOfArticles != deDupedArticles.numberOfArticles) {
+      logger.error(s"Attempt to save duplicate articles ${savedArticles.numberOfArticles}, deduped: ${deDupedArticles.numberOfArticles}")
     }
+    deDupedArticles
   }
 }

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -49,9 +49,9 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   override def advanceVersion: SavedArticles = copy(version = nextVersion)
   @JsonIgnore
   lazy val numberOfArticles = articles.length
-  lazy val dedupedArticles = articles.groupBy(_.id).map(_._2.sorted.head).toList.sorted  //NewestFirst
+  //NewestFirst
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
-  def deduped: SavedArticles = copy( articles = dedupedArticles.reverse )
+  def deduped: SavedArticles = copy( articles = articles.groupBy(_.id).map(_._2.sorted.head).toList.sorted.reverse )
   def persitable(limit: Int) = copy( articles = articles.sorted.reverse.takeRight(limit)  )
 }
 

--- a/src/main/scala/com/gu/sfl/model/model.scala
+++ b/src/main/scala/com/gu/sfl/model/model.scala
@@ -49,8 +49,10 @@ case class SavedArticles(version: String, articles: List[SavedArticle]) extends 
   override def advanceVersion: SavedArticles = copy(version = nextVersion)
   @JsonIgnore
   lazy val numberOfArticles = articles.length
+  lazy val dedupedArticles = articles.groupBy(_.id).map(_._2.sorted.head).toList.sorted  //NewestFirst
   def ordered: SavedArticles = copy(articles = articles.sorted.reverse)
-  def deduped = copy( articles = articles.groupBy(_.id).map(_._2.sorted.head).toList.sorted.reverse)
+  def deduped: SavedArticles = copy( articles = dedupedArticles.reverse )
+  def persitable(limit: Int) = copy( articles = articles.sorted.reverse.takeRight(limit)  )
 }
 
 case class ErrorResponse(status: String = "error", errors: List[Error])

--- a/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
+++ b/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
@@ -2,8 +2,8 @@ package com.gu.sfl.lib
 
 import java.time.LocalDateTime
 
-import com.gu.sfl.exception.{MaxSavedArticleTransgressionError, SavedArticleMergeError}
-import com.gu.sfl.model.{SavedArticle, SavedArticles, SyncedPrefs}
+import com.gu.sfl.exception.SavedArticleMergeError
+import com.gu.sfl.model.{SavedArticle, SavedArticles}
 import com.gu.sfl.persisitence.SavedArticlesPersistenceImpl
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification

--- a/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
+++ b/src/test/scala/com/gu/sfl/lib/ArticleMergeSpecification.scala
@@ -62,7 +62,7 @@ class ArticleMergeSpecification extends Specification with Mockito  {
     "will merge articles if there is a cnnflict" in new Setup {
       val articlesCurrentlySaved = SavedArticles("2", List(article1, article2))
       val articlesToSave = SavedArticles("1", List(article1, article2, article3))
-      val expectedMergedArticles = SavedArticles("2", List(article3, article2, article1))
+      val expectedMergedArticles = SavedArticles("2", List(article1, article2, article3))
       savedArticlesPersistence.read(userId) returns(Success(Some(articlesCurrentlySaved)))
       savedArticlesPersistence.update(any[String](), any[SavedArticles]()) returns(Success(Some(expectedMergedArticles.advanceVersion)))
       savedArticlesMerger.updateWithRetryAndMerge(userId, articlesToSave)
@@ -72,7 +72,7 @@ class ArticleMergeSpecification extends Specification with Mockito  {
     "will dedupe merged articles if there is a conflict" in new Setup {
       val articlesCurrentlySaved = SavedArticles("2", List(article1Dup, article2))
       val articlesToSave = SavedArticles("1", List(article1, article2, article3))
-      val expectedMergedArticles = SavedArticles("2", List(article3, article2, article1))
+      val expectedMergedArticles = SavedArticles("2", List(article1, article2, article3))
       savedArticlesPersistence.read(userId) returns(Success(Some(articlesCurrentlySaved)))
       savedArticlesPersistence.update(any[String](), any[SavedArticles]()) returns(Success(Some(expectedMergedArticles.advanceVersion)))
       savedArticlesMerger.updateWithRetryAndMerge(userId, articlesToSave)
@@ -80,14 +80,38 @@ class ArticleMergeSpecification extends Specification with Mockito  {
     }
     
 
-    "will not try to merge a list of articles with a length greater than the saved article limit" in new Setup {
+    "will select the latest articles up to the limit where the article limit is broken and there is no conflict`" in new Setup {
+      private val maxSavedArticlesLimit = 2
+
+      override val savedArticlesMerger = new SavedArticlesMergerImpl(SavedArticlesMergerConfig(maxSavedArticlesLimit), savedArticlesPersistence)
+      val expectedArticlesPersisted = savedArticles.copy(articles = List(article2, article3))
+      val expectedMergeResponse = Right(expectedArticlesPersisted.advanceVersion)
+      savedArticlesPersistence.update(any[String](), any[SavedArticles]()) returns(Success(Some(expectedArticlesPersisted.advanceVersion)))
+      savedArticlesPersistence.read(userId) returns(Success(Some(savedArticles)))
+      val saved = savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles2)
+
+      there were no (savedArticlesPersistence).write(any[String](), any[SavedArticles]())
+      there was one (savedArticlesPersistence).update(argThat(===(userId)), argThat(===(expectedArticlesPersisted)))
+      saved mustEqual(expectedMergeResponse)
+    }
+
+    "will select the latest articles up to the limit where the article limit is broken and there is a conflict" in new Setup {
       private val maxSavedArticlesLimit = 2
       override val savedArticlesMerger = new SavedArticlesMergerImpl(SavedArticlesMergerConfig(maxSavedArticlesLimit), savedArticlesPersistence)
-      val saved = savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles2)
-      there were no (savedArticlesPersistence).read(argThat(===(userId)))
+
+      val articlesCurrentlySaved = SavedArticles("2", List(article1, article2))
+      val articlesToSave = SavedArticles("1", List(article1, article2, article3))
+
+      //Returns an object consisting of the version currently saved and the latest 2 of th
+      val expectedArticlesPersisted = SavedArticles("2", List(article2, article3))
+      val expectedMergeResponse = Right(expectedArticlesPersisted.advanceVersion)
+
+      savedArticlesPersistence.read(any[String]()) returns(Success(Some(articlesCurrentlySaved)))
+      savedArticlesPersistence.update(any[String](), any[SavedArticles]()) returns(Success(Some(expectedArticlesPersisted.advanceVersion)))
+      val saved = savedArticlesMerger.updateWithRetryAndMerge(userId, articlesToSave)
       there were no (savedArticlesPersistence).write(any[String](), any[SavedArticles]())
-      there were no (savedArticlesPersistence).update(any[String](), any[SavedArticles]())
-      saved mustEqual(Left(MaxSavedArticleTransgressionError(s"The limit on number of saved articles is $maxSavedArticlesLimit")))
+      there was one (savedArticlesPersistence).update(argThat(===(userId)), argThat(===(expectedArticlesPersisted)))
+      saved mustEqual(expectedMergeResponse)
     }
 
     "will dedupe articles before checking whether the article limit hs been transgressed" in new Setup {

--- a/src/test/scala/com/gu/sfl/lib/deup.sc
+++ b/src/test/scala/com/gu/sfl/lib/deup.sc
@@ -1,5 +1,0 @@
-import java.time.{Instant, LocalDateTime}
-
-import com.gu.sfl.model.SavedArticle
-
-val next = Instant.now().toEpochMilli.toString


### PR DESCRIPTION
Take the most recent 1000 recent when a user saves. 

@alexduf as discussed. I want to keep the logging in that for de-duping which means this isn't as clean as it might be. Once I'm a more confident that all is well I'll remove that and refactor