### PR TITLE
do not persist saved articles that are identical to those already saved

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -36,7 +36,10 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
 
     savedArticlesPersistence.read(userId) match {
       case Success(Some(currentArticles)) if currentArticles.version == deduplicatedArticles.version =>
-        persistMergedArticles(userId, deduplicatedArticles)(savedArticlesPersistence.update)
+        if(currentArticles != deduplicatedArticles)
+          persistMergedArticles(userId, deduplicatedArticles)(savedArticlesPersistence.update)
+        else
+          Right(deduplicatedArticles)
       case Success(Some(currentArticles)) =>
         val articlesToSave = currentArticles.copy(articles = MergeLogic.mergeListBy(currentArticles.articles, deduplicatedArticles.articles)(_.id))
         persistMergedArticles(userId, articlesToSave)(savedArticlesPersistence.update)


### PR DESCRIPTION
Don't repersist articles when their the same as the ones already saved. This reduce our dynamo costs. Hopefully.

Note: When the versions are different I'm leaving as is