### PR TITLE
Revert "Move dynamo table to on demand"

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -36,6 +36,15 @@ Parameters:
     Description: Identity App Host
     Type: String
 
+Mappings:
+  StageVariables:
+    CODE:
+      TableReadCapacity: 1
+      TableWriteCapacity: 1
+    PROD:
+      TableReadCapacity: 75
+      TableWriteCapacity: 75
+
 Resources:
   SaveForLaterDynamoTable:
     Type: AWS::DynamoDB::Table
@@ -47,7 +56,9 @@ Resources:
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
-      BillingMode: PAY_PER_REQUEST
+      ProvisionedThroughput:
+        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
+        WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteCapacity ]
 
   SaveForLaterRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
That was a terrible idea, cost is nearly double for that type of load when using the on demand...

Woups 🤦‍♂ 