### PR TITLE
Revert "Fix security hole"

### DIFF
--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -26,9 +26,6 @@ Parameters:
   IdentityDeleteUserSnsTopicArnBase:
     Description: base form (sans platform) of the identity-account user deletion SNS
     Type: String
-  IdentityAccountId:
-    Description: The account ID of the Identity AWS account
-    Type: String
 
 Resources:
   UserDeletionRole:
@@ -87,7 +84,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Ref IdentityAccountId
+              AWS: "*"
             Action:
               - sqs:SendMessage
             Resource: !GetAtt UserIdDeleteQueue.Arn


### PR DESCRIPTION
Reverts guardian/mobile-save-for-later#37

It turns out we were fine all along. The [documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) says

> In these examples, the asterisk (*) is used as a placeholder for Everyone/Anonymous. You cannot use it as a wildcard to match part of a name or an ARN. We also strongly recommend that you do not use a wildcard in the Principal element in a role's trust policy unless you otherwise restrict access through a Condition element in the policy. Otherwise, any IAM user in any account can access the role. 