### PR TITLE
Add log line to identify version differences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 *.iml
 .idea
-/target
-/common/target
-/mobile-save-for-later/target
-/mobile-save-for-later-user-deletion/target
-/project/target
-/project/project/target
+target/

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -43,6 +43,7 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
         else
           Right(deduplicatedArticles)
       case Success(Some(currentArticles)) =>
+        logger.info(s"Received version ${deduplicatedArticles.version} from the client but had version ${currentArticles.version} in the database")
         val articlesToSave = currentArticles.copy(articles = MergeLogic.mergeListBy(currentArticles.articles, deduplicatedArticles.articles)(_.id))
         persistMergedArticles(userId, articlesToSave)(savedArticlesPersistence.update)
       case Success(None) =>


### PR DESCRIPTION
This is to identify how often do devices synchronize from an out of date version.

This might inform us regarding some of the save for later problem as discussed with @amajeedm