### PR TITLE
More precise logging

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -22,7 +22,7 @@ class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMer
       val eventualMaybeString = identityService.userFromRequest(identityHeaders)
       eventualMaybeString transformWith {
           case Success(Some(userId)) =>
-            logger.info(s"Attempting to save articles fo user: $userId")
+            logger.debug(s"Storing ${savedArticles.numberOfArticles} articles for user $userId")
             Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
           case Success(_) =>
             logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")


### PR DESCRIPTION
So that we can hopefully debug the service better.

The goal is to trace how many articles we currently have in the DB, and how many articles we received in the request.