### PR TITLE
Greater capacity

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -41,9 +41,11 @@ Mappings:
     CODE:
       TableReadCapacity: 1
       TableWriteCapacity: 1
+      ReservedConcurrency: 1
     PROD:
-      TableReadCapacity: 75
-      TableWriteCapacity: 75
+      TableReadCapacity: 100
+      TableWriteCapacity: 50
+      ReservedConcurrency: 50
 
 Resources:
   SaveForLaterDynamoTable:
@@ -222,8 +224,8 @@ Resources:
           App: !Ref App
           IdentityApiHost: !Ref IdentityApiHost
       MemorySize: 394
-      Timeout: 60
-      ReservedConcurrentExecutions: 100
+      Timeout: 20
+      ReservedConcurrentExecutions: !FindInMap [ StageVariables, !Ref Stage, ReservedConcurrency ]
       Events:
         GetApi:
           Type: Api
@@ -231,11 +233,3 @@ Resources:
            Path: "/syncedPrefs/me"
            Method: GET
            RestApiId: !Ref SaveForLaterApi
-
-
-
-
-
-
-
-

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -43,7 +43,7 @@ Mappings:
       TableWriteCapacity: 1
       ReservedConcurrency: 1
     PROD:
-      TableReadCapacity: 100
+      TableReadCapacity: 110
       TableWriteCapacity: 50
       ReservedConcurrency: 50
 


### PR DESCRIPTION
 - More reasonable reserved concurrency down to 50. Observed live is lower than 15 when table isn't saturated.
 - Smaller timeout at the lambda level. No need to hold for so long, let's free the lambda eagerly to reduce concurrency.
 - Increased provisioned read units to 110 to cope with the load.
 - Lower the provisioned write units to 50 as we don't seem to be using it.

