### PR TITLE
Add a cloudformation throttle alarm for save for later articles

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -240,6 +240,7 @@ Resources:
   SaveForLaterReadThrottleEvents:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub ${App}-${Stage}-articles-ReadCapacityUnitsLimit-BasicAlarm
       Namespace: AWS/DynamoDB
       MetricName: ReadThrottleEvents
       Unit: Count
@@ -256,6 +257,7 @@ Resources:
   SaveForLaterWriteThrottleEvents:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub ${App}-${Stage}-articles-WriteCapacityUnitsLimit-BasicAlarm
       Namespace: AWS/DynamoDB
       MetricName: WriteThrottleEvents
       Unit: Count

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -244,7 +244,7 @@ Resources:
       MetricName: ReadThrottleEvents
       Unit: Count
       Statistic: Sum
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: TableName
           Value: !Ref SaveForLaterDynamoTable
@@ -260,7 +260,7 @@ Resources:
       MetricName: WriteThrottleEvents
       Unit: Count
       Statistic: Sum
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: TableName
           Value: !Ref SaveForLaterDynamoTable

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -35,6 +35,9 @@ Parameters:
   IdentityApiHost:
     Description: Identity App Host
     Type: String
+  DynamoNotificationTopic:
+    Description: SNS topic to notify when there's a dynamo throttling event
+    Type: String
 
 Mappings:
   StageVariables:
@@ -233,3 +236,35 @@ Resources:
            Path: "/syncedPrefs/me"
            Method: GET
            RestApiId: !Ref SaveForLaterApi
+
+  SaveForLaterReadThrottleEvents:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Namespace: AWS/DynamoDB
+      MetricName: ReadThrottleEvents
+      Unit: Count
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: TableName
+          Value: !Ref SaveForLaterDynamoTable
+      Threshold: 0
+      Period: 60
+      EvaluationPeriods: 1
+      AlarmActions: [ !Ref DynamoNotificationTopic ]
+
+  SaveForLaterWriteThrottleEvents:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Namespace: AWS/DynamoDB
+      MetricName: WriteThrottleEvents
+      Unit: Count
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: TableName
+          Value: !Ref SaveForLaterDynamoTable
+      Threshold: 0
+      Period: 60
+      EvaluationPeriods: 1
+      AlarmActions: [ !Ref DynamoNotificationTopic ]


### PR DESCRIPTION
Add a cloudformation throttle alarm for save for later articles, and delete manually created alarms in cloudwatch.

Named:
`mobile-save-for-later-PROD-articles-ReadCapacityUnitsLimit-BasicAlarm`
`mobile-save-for-later-CODE-articles-ReadCapacityUnitsLimit-BasicAlarm`

@alexduf I should delete the `write` ones from the console too, presuming they have also manually been created?
`mobile-save-for-later-PROD-articles-WriteCapacityUnitsLimit-BasicAlarm`
`mobile-save-for-later-CODE-articles-WriteCapacityUnitsLimit-BasicAlarm`