### PR TITLE
Increase provisioned write capacity

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -47,7 +47,7 @@ Mappings:
       ReservedConcurrency: 1
     PROD:
       TableReadCapacity: 110
-      TableWriteCapacity: 50
+      TableWriteCapacity: 75
       ReservedConcurrency: 50
 
 Resources:


### PR DESCRIPTION
We have recently noticed write throttle events for this table:

![image](https://user-images.githubusercontent.com/19384074/81555963-6737dd00-9381-11ea-8d7e-0264db2ad0b5.png)

I've tried to guess a more appropriate threshold, based on [this advice](https://stackoverflow.com/a/17188893) and our current usage:

![image](https://user-images.githubusercontent.com/19384074/81556089-a2d2a700-9381-11ea-9f05-dd6f0b31e89a.png)
