### PR TITLE
LIVE-1068: Change DyanamoDB to pay per request

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -42,13 +42,9 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
-      TableReadCapacity: 1
-      TableWriteCapacity: 1
       ReservedConcurrency: 1
       AlarmActionsEnabled: FALSE
     PROD:
-      TableReadCapacity: 200
-      TableWriteCapacity: 75
       ReservedConcurrency: 50
       AlarmActionsEnabled: TRUE
 
@@ -63,9 +59,7 @@ Resources:
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
-        WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteCapacity ]
+      BillingMode: PAY_PER_REQUEST
 
   SaveForLaterRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## What does this change?
We should consider trialling the pay per request for our dynamo DB (for a week) and then we can estimate how much on average this would cost us a year.

This was tried before by Alex: https://github.com/guardian/mobile-save-for-later/pull/35 and swiftly rolled back because of spikes in costs, but it might work out cheaper in the long run than an engineer having to respond and react quickly to spikes to the service during high traffic news moments (i.e the US election)

We can monitor and then assess if this is the right approach or if we should try auto scaling as a longer term solution: https://github.com/guardian/mobile-save-for-later/pull/49

## How can we measure success?
If the costs don't spike too much and become too expensive.
