### PR TITLE
Revert "Revert "LIVE-1068: Change DyanamoDB to pay per request""

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -42,13 +42,9 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
-      TableReadCapacity: 1
-      TableWriteCapacity: 1
       ReservedConcurrency: 1
       AlarmActionsEnabled: FALSE
     PROD:
-      TableReadCapacity: 200
-      TableWriteCapacity: 75
       ReservedConcurrency: 50
       AlarmActionsEnabled: TRUE
 
@@ -63,9 +59,7 @@ Resources:
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
-        WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteCapacity ]
+      BillingMode: PAY_PER_REQUEST
 
   SaveForLaterRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Reverts guardian/mobile-save-for-later#52

We have noticed no significant increase in costs, which doesn't compare to a previous experiment. We have decided to lengthen the monitoring time to 1 month to get a fuller picture. We can then decide from there the action we take