### PR TITLE
Add CloudFormation to our deployment

### DIFF
--- a/mobile-save-for-later-user-deletion/riff-raff.yaml
+++ b/mobile-save-for-later-user-deletion/riff-raff.yaml
@@ -9,3 +9,8 @@ deployments:
       functionNames: [mobile-save-for-later-user-deletion-]
       fileName: mobile-save-for-later-user-deletion.jar
       prefixStack: false
+  mobile-save-for-later-user-deletion-cfn:
+    type: cloud-formation
+    app: mobile-save-for-later-user-deletion
+    parameters:
+      templatePath: cfn.yaml

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -51,6 +51,7 @@ Mappings:
 Resources:
   SaveForLaterDynamoTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
     Properties:
       TableName: !Sub ${App}-${Stage}-articles
       AttributeDefinitions:

--- a/mobile-save-for-later/riff-raff.yaml
+++ b/mobile-save-for-later/riff-raff.yaml
@@ -9,3 +9,8 @@ deployments:
       functionNames: [mobile-save-for-later-SAVE-, mobile-save-for-later-FETCH-]
       fileName: mobile-save-for-later.jar
       prefixStack: false
+  mobile-save-for-later-cfn:
+    type: cloud-formation
+    app: mobile-save-for-later
+    parameters:
+      templatePath: cfn.yaml


### PR DESCRIPTION
Add CloudFormation deployment so it keeps our stacks up to date in version control. This PR also adds a deletion policy to mitigate accidental deletions of tables. 
