### PR TITLE
Revert LIVE-1068: Change DyanamoDB to pay per request

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -42,9 +42,13 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
+      TableReadCapacity: 1
+      TableWriteCapacity: 1
       ReservedConcurrency: 1
       AlarmActionsEnabled: FALSE
     PROD:
+      TableReadCapacity: 200
+      TableWriteCapacity: 75
       ReservedConcurrency: 50
       AlarmActionsEnabled: TRUE
 
@@ -59,7 +63,9 @@ Resources:
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
-      BillingMode: PAY_PER_REQUEST
+      ProvisionedThroughput:
+        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
+        WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteCapacity ]
 
   SaveForLaterRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Reverts guardian/mobile-save-for-later#53

We have now tested the on demand pricing for a week, we can make an informed decision for what action we take, whether to keep with that or to put time in to producing auto scaling for the table. 

The cloudformation has been changed manually, this is to keep our repos up to date.