### PR TITLE
LIVE-1068: Add autoscaling for read to dynamo table

### DIFF
--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -42,12 +42,14 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
-      TableReadCapacity: 1
+      TableReadMinCapacity: 1
+      TableReadMaxCapacity: 10
       TableWriteCapacity: 1
       ReservedConcurrency: 1
       AlarmActionsEnabled: FALSE
     PROD:
-      TableReadCapacity: 200
+      TableReadMinCapacity: 110
+      TableReadMaxCapacity: 200
       TableWriteCapacity: 75
       ReservedConcurrency: 50
       AlarmActionsEnabled: TRUE
@@ -65,8 +67,32 @@ Resources:
         - AttributeName: userId
           KeyType: HASH
       ProvisionedThroughput:
-        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
+        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadMinCapacity ]
         WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteCapacity ]
+
+  SaveForLaterReadCapacityScalableTarget:
+    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    DependsOn: SaveForLaterDynamoTable
+    Properties:
+      MaxCapacity: !FindInMap [StageVariables, !Ref Stage, TableReadMaxCapacity]
+      MinCapacity: !FindInMap [StageVariables, !Ref Stage, TableReadMinCapacity]
+      ResourceId: !Sub table/${App}-${Stage}-articles
+      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable
+      ScalableDimension: "dynamodb:table:ReadCapacityUnits"
+      ServiceNamespace: dynamodb
+
+  SaveForLaterReadScalingPolicy:
+    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref SaveForLaterReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
 
   SaveForLaterRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
This PR aims to make the read capacity scalable following this guide:

https://aws.amazon.com/blogs/database/how-to-use-aws-cloudformation-to-configure-auto-scaling-for-amazon-dynamodb-tables-and-indexes/

Jamie W previously did this in this [PR](https://github.com/guardian/mobile-save-for-later/pull/49), as some time has passed it's easier to just reopen in a new PR. 
