### PR TITLE
update log4j dependency to fix security vulnerability

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val awsSdkVersion = "1.11.412"
-  val log4j2Version = "2.10.0"
+  val log4j2Version = "2.15.0"
   val jacksonVersion = "2.9.4"
   val specsVersion = "4.0.3"
 
@@ -10,7 +10,7 @@ object Dependencies {
   //Dependecies
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
-  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0"
+  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
   val awsJavaSdk ="com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion
   val awsSqs ="com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
   val awsLambdaEvent = "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   //Dependecies
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
-  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
+  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0"
   val awsJavaSdk ="com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion
   val awsSqs ="com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
   val awsLambdaEvent = "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.7")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?
Update log4j dependency to fix security vulnerability - see [doc](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo)

It also adds a dependency graph plugin so we can run the command `sbt dependencyBrowseTree` which a handy way to quickly view our dependency tree in a browser: https://github.com/sbt/sbt-dependency-graph

## How to test

Ran tests locally