### PR TITLE
Update aws-lambda-java-log4j2 to fix security vulnerability

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   //Dependecies
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
-  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0"
+  val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0"
   val awsJavaSdk ="com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion
   val awsSqs ="com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
   val awsLambdaEvent = "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"


### PR DESCRIPTION
## What does this change?
Updates aws-lambda-java-log4j2 to the latest version to help fix security vulnerability