### PR TITLE
Use identifiers endpoint 

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -47,6 +47,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
            node.path("id").textValue
          } match {
            case Success(userId) =>
+             // .textValue can return null, so wrap in Option.apply
              promise.success(Option(userId))
            case Failure(_)  =>
              promise.success(None)

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -21,7 +21,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
 
   override def userFromRequest(identityHeaders: IdentityHeader): Future[Option[String]] = {
 
-    val meUrl = s"${identityConfig.identityApiHost}/user/me"
+    val meUrl = s"${identityConfig.identityApiHost}/user/me/identifiers"
 
     val headers = new Headers.Builder()
       .add("X-GU-ID-Client-Access-Token", identityHeaders.accessToken)
@@ -44,7 +44,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
            val body = response.body().string()
            logger.debug(s"Identity api response: $body")
            val node = mapper.readTree(body.getBytes)
-           node.get("user").path("id").textValue
+           node.path("id").textValue
          } match {
            case Success(userId) => promise.success(Some(userId))
            case Failure(_)  => promise.success(None)

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -46,8 +46,10 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
            val node = mapper.readTree(body.getBytes)
            node.path("id").textValue
          } match {
-           case Success(userId) => promise.success(Some(userId))
-           case Failure(_)  => promise.success(None)
+           case Success(userId) =>
+             promise.success(Option(userId))
+           case Failure(_)  =>
+             promise.success(None)
          }
       }
 

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -41,6 +41,16 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
       }
 
     }
+
+    "return future failed when identity returns 503" in new MockErrorResponseScope {
+      val idFailResult =  Await.ready(identityService.userFromRequest(identityHeaders), Duration.Inf).value.get
+
+      idFailResult match {
+        case Success(_) => fail("No IOxception thrown")
+        case Failure(e) => e mustEqual(IdentityApiRequestError("Identity api server error"))
+      }
+
+    }
   }
 
   trait IdentityRequestFailsScope extends MockHttpRequestScope {
@@ -53,6 +63,11 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
   trait MockBadIdResponseScope extends MockHttpRequestScope {
     override val body = """{"status":"error","errors":[{"message":"Access Denied","description":"Access Denied"}]}"""
     override val code = 403
+  }
+
+  trait MockErrorResponseScope extends MockHttpRequestScope {
+    override val body = """service not available"""
+    override val code = 503
   }
 
   trait MockHttpRequestScope extends Scope {

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -69,7 +69,12 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     //This is a cutdown of what the actual id response is
-    def body: String = """{ "status": "ok", "user": { "id": "1234" 	} }"""
+    def body: String = """{
+                         |  "id": "1234",
+                         |  "brazeUuid": "aaaaaaaaaa",
+                         |  "puzzleId": "aaaaaaaaaaaaaaaaaaaaa",
+                         |  "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                         |}""".stripMargin
     def code: Int = 200
 
     val httpClient = mock[OkHttpClient]


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Authorise app requests using identity user identifiers endpoint to avoid hitting okta rate limit quotas.

`user/me/identifiers` does not hit okta endpoints, so does not incur rate limit cost
