### PR TITLE
Use a new identity endpoint and do not log users out on 5XX code

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -21,7 +21,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
 
   override def userFromRequest(identityHeaders: IdentityHeader): Future[Option[String]] = {
 
-    val meUrl = s"${identityConfig.identityApiHost}/user/me"
+    val meUrl = s"${identityConfig.identityApiHost}/user/me/identifiers"
 
     val headers = new Headers.Builder()
       .add("X-GU-ID-Client-Access-Token", identityHeaders.accessToken)
@@ -36,19 +36,35 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
       .get()
       .build()
 
+    def extractUserIdFromSuccessResult(response: Response) = {
+      Try {
+        val body = response.body().string()
+        logger.debug(s"Identity api response: $body")
+        val node = mapper.readTree(body.getBytes)
+        node.path("id").textValue
+      } match {
+        case Success(userId) =>
+          // .textValue can return null, so wrap in Option.apply
+          promise.success(Option(userId))
+        case Failure(_) =>
+          promise.success(None)
+      }
+    }
+
     okHttpClient.newCall(
       request
     ).enqueue(new Callback {
       override def onResponse(call: Call, response: Response): Unit = {
-        Try {
-           val body = response.body().string()
-           logger.debug(s"Identity api response: $body")
-           val node = mapper.readTree(body.getBytes)
-           node.get("user").path("id").textValue
-         } match {
-           case Success(userId) => promise.success(Some(userId))
-           case Failure(_)  => promise.success(None)
-         }
+        val responseCodeGroup = response.code() / 100
+
+        // 5XX responses should not log users out, so fail the promise instead of returning None
+        if (responseCodeGroup == 5) {
+          promise.failure(IdentityApiRequestError("Identity api server error"))
+        } else if (responseCodeGroup == 2) {
+          extractUserIdFromSuccessResult(response)
+        } else {
+          promise.success(None)
+        }
       }
 
       override def onFailure(call: Call, e: IOException): Unit = promise.failure(IdentityApiRequestError("Did not get identiy api response"))

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -41,6 +41,16 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
       }
 
     }
+
+    "return future failed when identity returns 503" in new MockErrorResponseScope {
+      val idFailResult =  Await.ready(identityService.userFromRequest(identityHeaders), Duration.Inf).value.get
+
+      idFailResult match {
+        case Success(_) => fail("No IOxception thrown")
+        case Failure(e) => e mustEqual(IdentityApiRequestError("Identity api server error"))
+      }
+
+    }
   }
 
   trait IdentityRequestFailsScope extends MockHttpRequestScope {
@@ -53,6 +63,11 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
   trait MockBadIdResponseScope extends MockHttpRequestScope {
     override val body = """{"status":"error","errors":[{"message":"Access Denied","description":"Access Denied"}]}"""
     override val code = 403
+  }
+
+  trait MockErrorResponseScope extends MockHttpRequestScope {
+    override val body = """service not available"""
+    override val code = 503
   }
 
   trait MockHttpRequestScope extends Scope {
@@ -69,7 +84,12 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     //This is a cutdown of what the actual id response is
-    def body: String = """{ "status": "ok", "user": { "id": "1234" 	} }"""
+    def body: String = """{
+                         |  "id": "1234",
+                         |  "brazeUuid": "braze1234",
+                         |  "puzzleId": "puzzle1234",
+                         |  "googleTagId": "googleTag1234"
+                         |}""".stripMargin
     def code: Int = 200
 
     val httpClient = mock[OkHttpClient]


### PR DESCRIPTION
Thanks to (Peter Colley) 

Authorise app requests using identity user identifiers endpoint to avoid hitting okta rate limit quotas.

user/me/identifiers does not hit okta endpoints, so does not incur rate limit cost