### PR TITLE
Add cdk-defined version of API infrastructre

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,13 +1,29 @@
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
+import type { MobileSaveForLaterProps } from "../lib/mobile-save-for-later";
 import { MobileSaveForLater } from "../lib/mobile-save-for-later";
 
 const app = new App();
-new MobileSaveForLater(app, "MobileSaveForLater-CODE", {
+
+export const codeProps: MobileSaveForLaterProps = {
   stack: "mobile",
   stage: "CODE",
-});
-new MobileSaveForLater(app, "MobileSaveForLater-PROD", {
+  certificateId: "b4c2902a-fc80-47a9-88b7-7810b88e7e26",
+  domainName: "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
+  hostedZoneName: "mobile-aws.code.dev-guardianapis.com",
+  hostedZoneId: "Z6PRU8YR6TQDK",
+  identityApiHost: "https://id.code.dev-guardianapis.com",
+};
+
+export const prodProps: MobileSaveForLaterProps = {
   stack: "mobile",
   stage: "PROD",
-});
+  certificateId: "0ee21f37-ec53-437c-b572-3c9d294ab749",
+  domainName: "mobile-save-for-later.mobile-aws.guardianapis.com",
+  hostedZoneName: "mobile-aws.guardianapis.com",
+  hostedZoneId: "Z1EYB4AREPXE3B",
+  identityApiHost: "https://id.guardianapis.com",
+};
+
+new MobileSaveForLater(app, "MobileSaveForLater-CODE", codeProps);
+new MobileSaveForLater(app, "MobileSaveForLater-PROD", prodProps);

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -19,6 +19,34 @@ Object {
       },
     },
   },
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
   "Parameters": Object {
     "App": Object {
       "Default": "mobile-save-for-later",
@@ -33,6 +61,11 @@ Object {
       "Default": "mobile-dist",
       "Description": "S3 Bucket where riff-raff uploads artifacts on deploy",
       "Type": "String",
+    },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DynamoNotificationTopic": Object {
       "Description": "SNS topic to notify when there's a dynamo throttling event",
@@ -92,7 +125,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -200,7 +233,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
         "Timeout": 20,
@@ -235,6 +268,417 @@ Object {
           "Fn::GetAtt": "FetchArticlesLambda.Arn",
         },
         "Principal": "apigateway.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "Name": "mobile-save-for-later-api-CODE",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "RestApiDeployment180EC5035ed39622d7840f196ed35b5345f76c92": Object {
+      "DependsOn": Array [
+        "RestApisyncedPrefsmeGET26EA27DA",
+        "RestApisyncedPrefsme43E29A67",
+        "RestApisyncedPrefsmesavedArticlesPOST431289B1",
+        "RestApisyncedPrefsmesavedArticles1FBF9E72",
+        "RestApisyncedPrefsC6D26086",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC5035ed39622d7840f196ed35b5345f76c92",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApisyncedPrefsC6D26086": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "syncedPrefs",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsme43E29A67": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "RestApisyncedPrefsC6D26086",
+        },
+        "PathPart": "me",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsmeGET26EA27DA": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "fetcharticleslambda4E2BF026",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "RestApisyncedPrefsme43E29A67",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApisyncedPrefsmeGETApiPermissionMobileSaveForLaterCODERestApi17248814GETsyncedPrefsme8119A20D": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambda4E2BF026",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              Object {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/syncedPrefs/me",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmeGETApiPermissionTestMobileSaveForLaterCODERestApi17248814GETsyncedPrefsme36E6A8D1": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambda4E2BF026",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/syncedPrefs/me",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmesavedArticles1FBF9E72": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "RestApisyncedPrefsme43E29A67",
+        },
+        "PathPart": "savedArticles",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOST431289B1": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "savearticleslambda95B3C5F6",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "RestApisyncedPrefsmesavedArticles1FBF9E72",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOSTApiPermissionMobileSaveForLaterCODERestApi17248814POSTsyncedPrefsmesavedArticlesF9771EF1": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambda95B3C5F6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              Object {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/syncedPrefs/me/savedArticles",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOSTApiPermissionTestMobileSaveForLaterCODERestApi17248814POSTsyncedPrefsmesavedArticles7BBB5472": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambda95B3C5F6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/syncedPrefs/me/savedArticles",
+            ],
+          ],
+        },
       },
       "Type": "AWS::Lambda::Permission",
     },
@@ -295,7 +739,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
         "Timeout": 60,
@@ -392,7 +836,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -434,7 +878,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -493,7 +937,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -628,7 +1072,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -672,6 +1116,2139 @@ Object {
         "Unit": "Count",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "fetcharticleslambda4E2BF026": Object {
+      "DependsOn": Array [
+        "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A",
+        "fetcharticleslambdaServiceRoleC5815D5D",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile/CODE/mobile-save-for-later/mobile-save-for-later.jar",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "mobile-save-for-later",
+            "App": "mobile-save-for-later",
+            "IdentityApiHost": "https://id.code.dev-guardianapis.com",
+            "STACK": "mobile",
+            "STAGE": "CODE",
+            "Stack": "mobile",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "mobile-save-for-later-FETCH-cdk-CODE",
+        "Handler": "com.gu.sfl.lambda.FetchArticlesLambda::handleRequest",
+        "MemorySize": 1024,
+        "ReservedConcurrentExecutions": 1,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambdaServiceRoleC5815D5D",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 20,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "fetcharticleslambdaServiceRoleC5815D5D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile/mobile-save-for-later",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile/mobile-save-for-later/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/mobile-save-for-later/CODE/mobile",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudwatch:putMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "SaveForLaterDynamoTable",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A",
+        "Roles": Array [
+          Object {
+            "Ref": "fetcharticleslambdaServiceRoleC5815D5D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "savearticleslambda95B3C5F6": Object {
+      "DependsOn": Array [
+        "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9",
+        "savearticleslambdaServiceRole0DD4D7BB",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile/CODE/mobile-save-for-later/mobile-save-for-later.jar",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "mobile-save-for-later",
+            "App": "mobile-save-for-later",
+            "IdentityApiHost": "https://id.code.dev-guardianapis.com",
+            "STACK": "mobile",
+            "STAGE": "CODE",
+            "SavedArticleLimit": "1000",
+            "Stack": "mobile",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "mobile-save-for-later-SAVE-cdk-CODE",
+        "Handler": "com.gu.sfl.lambda.SaveArticlesLambda::handleRequest",
+        "MemorySize": 1024,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambdaServiceRole0DD4D7BB",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "savearticleslambdaServiceRole0DD4D7BB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile/mobile-save-for-later",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile/mobile-save-for-later/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/mobile-save-for-later/CODE/mobile",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudwatch:putMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "SaveForLaterDynamoTable",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9",
+        "Roles": Array [
+          Object {
+            "Ref": "savearticleslambdaServiceRole0DD4D7BB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;
+
+exports[`The MobileSaveForLater stack matches the snapshot 2`] = `
+Object {
+  "Description": "Implements save for later for mobile",
+  "Mappings": Object {
+    "StageVariables": Object {
+      "CODE": Object {
+        "AlarmActionsEnabled": false,
+        "ReservedConcurrency": 1,
+        "TableReadCapacity": 1,
+        "TableWriteCapacity": 1,
+      },
+      "PROD": Object {
+        "AlarmActionsEnabled": true,
+        "ReservedConcurrency": 50,
+        "TableReadCapacity": 200,
+        "TableWriteCapacity": 75,
+      },
+    },
+  },
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "App": Object {
+      "Default": "mobile-save-for-later",
+      "Description": "Application name",
+      "Type": "String",
+    },
+    "CertArn": Object {
+      "Description": "ACM Certificate ARN",
+      "Type": "String",
+    },
+    "DeployBucket": Object {
+      "Default": "mobile-dist",
+      "Description": "S3 Bucket where riff-raff uploads artifacts on deploy",
+      "Type": "String",
+    },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "DynamoNotificationTopic": Object {
+      "Description": "SNS topic to notify when there's a dynamo throttling event",
+      "Type": "String",
+    },
+    "HostedZoneId": Object {
+      "Description": "Id of HostedZone",
+      "Type": "String",
+    },
+    "HostedZoneName": Object {
+      "Description": "Name of HostedZone",
+      "Type": "String",
+    },
+    "IdentityApiHost": Object {
+      "Description": "Identity App Host",
+      "Type": "String",
+    },
+    "SavedArticleLimit": Object {
+      "Description": "Saved article limit",
+      "Type": "Number",
+    },
+    "Stack": Object {
+      "Default": "mobile",
+      "Description": "Stack name",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "ApiDomainName": Object {
+      "Properties": Object {
+        "CertificateArn": Object {
+          "Ref": "CertArn",
+        },
+        "DomainName": Object {
+          "Fn::Sub": "\${App}.\${HostedZoneName}",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "ApiMapping": Object {
+      "Properties": Object {
+        "DomainName": Object {
+          "Ref": "ApiDomainName",
+        },
+        "RestApiId": Object {
+          "Ref": "SaveForLaterApi",
+        },
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "ApiRoute53": Object {
+      "Properties": Object {
+        "HostedZoneId": Object {
+          "Ref": "HostedZoneId",
+        },
+        "RecordSets": Array [
+          Object {
+            "AliasTarget": Object {
+              "DNSName": Object {
+                "Fn::GetAtt": Array [
+                  "ApiDomainName",
+                  "DistributionDomainName",
+                ],
+              },
+              "HostedZoneId": "Z2FDTNDATAQYW2",
+            },
+            "Name": Object {
+              "Ref": "ApiDomainName",
+            },
+            "Type": "A",
+          },
+        ],
+      },
+      "Type": "AWS::Route53::RecordSetGroup",
+    },
+    "FetchArticlesLambda": Object {
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DeployBucket",
+          },
+          "S3Key": Object {
+            "Fn::Sub": "\${Stack}/\${Stage}/\${App}/\${App}.jar",
+          },
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "App": Object {
+              "Ref": "App",
+            },
+            "IdentityApiHost": Object {
+              "Ref": "IdentityApiHost",
+            },
+            "Stack": Object {
+              "Ref": "Stack",
+            },
+            "Stage": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Sub": "\${App}-FETCH-\${Stage}",
+        },
+        "Handler": "com.gu.sfl.lambda.FetchArticlesLambda::handleRequest",
+        "MemorySize": 394,
+        "ReservedConcurrentExecutions": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "ReservedConcurrency",
+          ],
+        },
+        "Role": Object {
+          "Fn::GetAtt": "SaveForLaterRole.Arn",
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 20,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "FetchArticlesLambdaGetApiPermissionStage": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "FetchArticlesLambda",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Sub": Array [
+            "arn:aws:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/GET/syncedPrefs/me",
+            Object {
+              "__ApiId__": Object {
+                "Ref": "SaveForLaterApi",
+              },
+              "__Stage__": "*",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "FetchArticlesLambdaPermission": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": "FetchArticlesLambda.Arn",
+        },
+        "Principal": "apigateway.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "Name": "mobile-save-for-later-api-PROD",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "RestApiDeployment180EC503a9713084f6e42c3174f3f6569d53b59c": Object {
+      "DependsOn": Array [
+        "RestApisyncedPrefsmeGET26EA27DA",
+        "RestApisyncedPrefsme43E29A67",
+        "RestApisyncedPrefsmesavedArticlesPOST431289B1",
+        "RestApisyncedPrefsmesavedArticles1FBF9E72",
+        "RestApisyncedPrefsC6D26086",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC503a9713084f6e42c3174f3f6569d53b59c",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApisyncedPrefsC6D26086": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "syncedPrefs",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsme43E29A67": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "RestApisyncedPrefsC6D26086",
+        },
+        "PathPart": "me",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsmeGET26EA27DA": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "fetcharticleslambda4E2BF026",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "RestApisyncedPrefsme43E29A67",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApisyncedPrefsmeGETApiPermissionMobileSaveForLaterPRODRestApi34373EB6GETsyncedPrefsme64F5DB87": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambda4E2BF026",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              Object {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/syncedPrefs/me",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmeGETApiPermissionTestMobileSaveForLaterPRODRestApi34373EB6GETsyncedPrefsmeFCFC8C36": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambda4E2BF026",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/syncedPrefs/me",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmesavedArticles1FBF9E72": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Ref": "RestApisyncedPrefsme43E29A67",
+        },
+        "PathPart": "savedArticles",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOST431289B1": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "savearticleslambda95B3C5F6",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "RestApisyncedPrefsmesavedArticles1FBF9E72",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOSTApiPermissionMobileSaveForLaterPRODRestApi34373EB6POSTsyncedPrefsmesavedArticles6E19EABE": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambda95B3C5F6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              Object {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/syncedPrefs/me/savedArticles",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApisyncedPrefsmesavedArticlesPOSTApiPermissionTestMobileSaveForLaterPRODRestApi34373EB6POSTsyncedPrefsmesavedArticles4E00ABB7": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambda95B3C5F6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/syncedPrefs/me/savedArticles",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "SaveArticlesLambda": Object {
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DeployBucket",
+          },
+          "S3Key": Object {
+            "Fn::Sub": "\${Stack}/\${Stage}/\${App}/\${App}.jar",
+          },
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "App": Object {
+              "Ref": "App",
+            },
+            "IdentityApiHost": Object {
+              "Ref": "IdentityApiHost",
+            },
+            "SavedArticleLimit": Object {
+              "Ref": "SavedArticleLimit",
+            },
+            "Stack": Object {
+              "Ref": "Stack",
+            },
+            "Stage": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Sub": "\${App}-SAVE-\${Stage}",
+        },
+        "Handler": "com.gu.sfl.lambda.SaveArticlesLambda::handleRequest",
+        "MemorySize": 384,
+        "Role": Object {
+          "Fn::GetAtt": "SaveForLaterRole.Arn",
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SaveArticlesLambdaPostApiPermissionStage": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "SaveArticlesLambda",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Sub": Array [
+            "arn:aws:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/POST/syncedPrefs/me/savedArticles",
+            Object {
+              "__ApiId__": Object {
+                "Ref": "SaveForLaterApi",
+              },
+              "__Stage__": "*",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "SaveForLaterApi": Object {
+      "Properties": Object {
+        "Body": Object {
+          "info": Object {
+            "title": Object {
+              "Fn::Sub": "\${App}-\${Stage}",
+            },
+            "version": "1.0.0",
+          },
+          "paths": Object {
+            "/syncedPrefs/me": Object {
+              "get": Object {
+                "produces": Array [
+                  "application/json",
+                ],
+                "responses": Object {
+                  "200": Object {
+                    "description": "200 response",
+                  },
+                },
+                "x-amazon-apigateway-integration": Object {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": Object {
+                    "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${FetchArticlesLambda.Arn}/invocations",
+                  },
+                },
+              },
+            },
+            "/syncedPrefs/me/savedArticles": Object {
+              "post": Object {
+                "consumes": Array [
+                  "application/json",
+                ],
+                "produces": Array [
+                  "application/json",
+                ],
+                "responses": Object {
+                  "200": Object {
+                    "description": "200 response",
+                  },
+                },
+                "x-amazon-apigateway-integration": Object {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": Object {
+                    "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${SaveArticlesLambda.Arn}/invocations",
+                  },
+                },
+              },
+            },
+          },
+          "swagger": "2.0",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "SaveForLaterApiDeployment7818545d6f": Object {
+      "Properties": Object {
+        "Description": "RestApi deployment id: 7818545d6f935a518be3b1f7ecebec1729443529",
+        "RestApiId": Object {
+          "Ref": "SaveForLaterApi",
+        },
+        "StageName": "Stage",
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "SaveForLaterApiStage": Object {
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "SaveForLaterApiDeployment7818545d6f",
+        },
+        "RestApiId": Object {
+          "Ref": "SaveForLaterApi",
+        },
+        "StageName": Object {
+          "Ref": "Stage",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "SaveForLaterDynamoTable": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "userId",
+            "AttributeType": "S",
+          },
+        ],
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "userId",
+            "KeyType": "HASH",
+          },
+        ],
+        "ProvisionedThroughput": Object {
+          "ReadCapacityUnits": Object {
+            "Fn::FindInMap": Array [
+              "StageVariables",
+              Object {
+                "Ref": "Stage",
+              },
+              "TableReadCapacity",
+            ],
+          },
+          "WriteCapacityUnits": Object {
+            "Fn::FindInMap": Array [
+              "StageVariables",
+              Object {
+                "Ref": "Stage",
+              },
+              "TableWriteCapacity",
+            ],
+          },
+        },
+        "TableName": Object {
+          "Fn::Sub": "\${App}-\${Stage}-articles",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+    },
+    "SaveForLaterReadThrottleEvents": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Ref": "DynamoNotificationTopic",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App}-\${Stage}-articles-ReadCapacityUnitsLimit-BasicAlarm",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": Object {
+              "Ref": "SaveForLaterDynamoTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "SaveForLaterRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Object {
+                "Action": Array [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:PutLogEvents",
+                ],
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            },
+            "PolicyName": "logs",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Object {
+                "Action": Array [
+                  "ssm:GetParametersByPath",
+                ],
+                "Effect": "Allow",
+                "Resource": Object {
+                  "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/\${App}/\${Stage}/\${Stack}",
+                },
+              },
+            },
+            "PolicyName": "ssm-config",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Object {
+                "Action": Array [
+                  "dynamodb:GetItem",
+                  "dynamodb:PutItem",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:Query",
+                ],
+                "Effect": "Allow",
+                "Resource": Object {
+                  "Fn::Sub": "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/\${App}-\${Stage}-articles",
+                },
+              },
+            },
+            "PolicyName": "dynamo-action",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Object {
+                "Action": Array [
+                  "cloudwatch:PutMetricData",
+                ],
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            },
+            "PolicyName": "metrics",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SaveForLaterWriteThrottleEvents": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Ref": "DynamoNotificationTopic",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App}-\${Stage}-articles-WriteCapacityUnitsLimit-BasicAlarm",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": Object {
+              "Ref": "SaveForLaterDynamoTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "fetcharticleslambda4E2BF026": Object {
+      "DependsOn": Array [
+        "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A",
+        "fetcharticleslambdaServiceRoleC5815D5D",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile/PROD/mobile-save-for-later/mobile-save-for-later.jar",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "mobile-save-for-later",
+            "App": "mobile-save-for-later",
+            "IdentityApiHost": "https://id.guardianapis.com",
+            "STACK": "mobile",
+            "STAGE": "PROD",
+            "Stack": "mobile",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "mobile-save-for-later-FETCH-cdk-PROD",
+        "Handler": "com.gu.sfl.lambda.FetchArticlesLambda::handleRequest",
+        "MemorySize": 1024,
+        "ReservedConcurrentExecutions": 50,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "fetcharticleslambdaServiceRoleC5815D5D",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 20,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "fetcharticleslambdaServiceRoleC5815D5D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/mobile/mobile-save-for-later",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/mobile/mobile-save-for-later/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/mobile-save-for-later/PROD/mobile",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudwatch:putMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "SaveForLaterDynamoTable",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "fetcharticleslambdaServiceRoleDefaultPolicy4A85964A",
+        "Roles": Array [
+          Object {
+            "Ref": "fetcharticleslambdaServiceRoleC5815D5D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "savearticleslambda95B3C5F6": Object {
+      "DependsOn": Array [
+        "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9",
+        "savearticleslambdaServiceRole0DD4D7BB",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile/PROD/mobile-save-for-later/mobile-save-for-later.jar",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "mobile-save-for-later",
+            "App": "mobile-save-for-later",
+            "IdentityApiHost": "https://id.guardianapis.com",
+            "STACK": "mobile",
+            "STAGE": "PROD",
+            "SavedArticleLimit": "1000",
+            "Stack": "mobile",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "mobile-save-for-later-SAVE-cdk-PROD",
+        "Handler": "com.gu.sfl.lambda.SaveArticlesLambda::handleRequest",
+        "MemorySize": 1024,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "savearticleslambdaServiceRole0DD4D7BB",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "savearticleslambdaServiceRole0DD4D7BB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "mobile-save-for-later",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-save-for-later",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/mobile/mobile-save-for-later",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/mobile/mobile-save-for-later/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/mobile-save-for-later/PROD/mobile",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudwatch:putMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "SaveForLaterDynamoTable",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "savearticleslambdaServiceRoleDefaultPolicy6E40CEA9",
+        "Roles": Array [
+          Object {
+            "Ref": "savearticleslambdaServiceRole0DD4D7BB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/cdk/lib/mobile-save-for-later.test.ts
+++ b/cdk/lib/mobile-save-for-later.test.ts
@@ -1,15 +1,22 @@
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { codeProps, prodProps } from "../bin/cdk";
 import { MobileSaveForLater } from "./mobile-save-for-later";
 
 describe("The MobileSaveForLater stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const stack = new MobileSaveForLater(app, "MobileSaveForLater", {
-      stack: "mobile",
-      stage: "TEST",
-    });
-    const template = Template.fromStack(stack);
-    expect(template.toJSON()).toMatchSnapshot();
+    const codeStack = new MobileSaveForLater(
+      app,
+      "MobileSaveForLater-CODE",
+      codeProps
+    );
+    const prodStack = new MobileSaveForLater(
+      app,
+      "MobileSaveForLater-PROD",
+      prodProps
+    );
+    expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+    expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
   });
 });

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -1,19 +1,134 @@
 import { join } from "path";
+import { GuApiGatewayWithLambdaByPath } from "@guardian/cdk";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
 import type { App } from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
+import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
+export interface MobileSaveForLaterProps extends GuStackProps {
+  certificateId: string;
+  domainName: string;
+  hostedZoneName: string;
+  hostedZoneId: string;
+  identityApiHost: string;
+}
+
 export class MobileSaveForLater extends GuStack {
-  constructor(scope: App, id: string, props: GuStackProps) {
+  constructor(scope: App, id: string, props: MobileSaveForLaterProps) {
     super(scope, id, props);
+
     const yamlTemplateFilePath = join(
       __dirname,
       "../..",
       "mobile-save-for-later/conf/cfn.yaml"
     );
-    new CfnInclude(this, "YamlTemplate", {
+    const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
       templateFile: yamlTemplateFilePath,
     });
+
+    const app = "mobile-save-for-later";
+
+    const commonLambdaProps = {
+      runtime: Runtime.JAVA_8, // We should upgrade to Java 11 in a future PR
+      app,
+      fileName: `${app}.jar`,
+      // N.B. these lambdas previously used very specific, low memory sizes (384 & 394); odd choices for a Scala Lambda
+    };
+
+    const commonEnvironmentVariables = {
+      App: app,
+      Stack: this.stack,
+      Stage: this.stage,
+      IdentityApiHost: props.identityApiHost,
+    };
+
+    const saveArticlesLambda = new GuLambdaFunction(
+      this,
+      "save-articles-lambda",
+      {
+        handler: "com.gu.sfl.lambda.SaveArticlesLambda::handleRequest",
+        functionName: `mobile-save-for-later-SAVE-cdk-${this.stage}`,
+        environment: {
+          ...commonEnvironmentVariables,
+          SavedArticleLimit: "1000",
+        },
+        ...commonLambdaProps,
+      }
+    );
+
+    const fetchArticlesLambda = new GuLambdaFunction(
+      this,
+      "fetch-articles-lambda",
+      {
+        handler: "com.gu.sfl.lambda.FetchArticlesLambda::handleRequest",
+        functionName: `mobile-save-for-later-FETCH-cdk-${this.stage}`,
+        timeout: Duration.seconds(20),
+        reservedConcurrentExecutions: this.stage === "PROD" ? 50 : 1,
+        environment: commonEnvironmentVariables,
+        ...commonLambdaProps,
+      }
+    );
+
+    [saveArticlesLambda, fetchArticlesLambda].map((lambda) => {
+      // permissions for the departmental standard are provided by cdk 'for free' but we cannot
+      // use them here because our parameter path used differs from the departmental standard
+      lambda.addToRolePolicy(
+        new PolicyStatement({
+          actions: ["ssm:GetParametersByPath"],
+          resources: [
+            `arn:aws:ssm:${this.region}:${this.account}:parameter/${app}/${this.stage}/${this.stack}`,
+          ],
+        })
+      );
+      lambda.addToRolePolicy(
+        new PolicyStatement({
+          actions: ["cloudwatch:putMetricData"],
+          resources: ["*"],
+        })
+      );
+      lambda.addToRolePolicy(
+        new PolicyStatement({
+          actions: [
+            "dynamodb:GetItem",
+            "dynamodb:PutItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:Query",
+          ],
+          resources: [
+            yamlDefinedResources
+              .getResource("SaveForLaterDynamoTable")
+              // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#aws-resource-dynamodb-table-return-values
+              .getAtt("Arn")
+              .toString(),
+          ],
+        })
+      );
+    });
+
+    const saveForLaterApi = new GuApiGatewayWithLambdaByPath(this, {
+      app,
+      restApiName: `${app}-api-${this.stage}`,
+      monitoringConfiguration: { noMonitoring: true }, //TODO: configure monitoring (this is not setup in current CFN)
+      targets: [
+        {
+          path: "/syncedPrefs/me/savedArticles",
+          httpMethod: "POST",
+          lambda: saveArticlesLambda,
+        },
+        {
+          path: "/syncedPrefs/me",
+          httpMethod: "GET",
+          lambda: fetchArticlesLambda,
+        },
+      ],
+    });
+
+    // TODO:
+    // Move into cdk: DNS configuration
+    // Decide whether to port across or leave in CFN: Dynamo Table & Dynamo Throttle CloudWatch Alarms
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,7 +11,7 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "43.0.0",
+    "@guardian/cdk": "43.3.1-beta.1",
     "@guardian/eslint-config-typescript": "1.0.1",
     "@types/jest": "^27.5.0",
     "@types/node": "17.0.31",

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -306,16 +306,16 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@43.0.0":
-  version "43.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-43.0.0.tgz#9a504835cd7be80cb99fe1b2cbcf1c3038c1826b"
-  integrity sha512-e0uRU/3AhmsXTedoiqqAw50YlgsiNRdOFZhR1+UZ3UwvvwgMZSZwISdTjKiuWglDi8SuLFDMdgRRw6529By1YQ==
+"@guardian/cdk@43.3.1-beta.1":
+  version "43.3.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-43.3.1-beta.1.tgz#a3da33ab0d4ac28e00caec53f46c788f94da8bb9"
+  integrity sha512-7ZVX8XYAdN6eFFm69XtuovHcUqFvZnjrXf/pfMKlzlc1j3SXW80CFXogVryepnjTQEninkRGBpAzBiC/pBccdA==
   dependencies:
-    "@oclif/core" "1.8.0"
+    "@oclif/core" "1.8.1"
     aws-cdk-lib "2.23.0"
-    aws-sdk "^2.1127.0"
+    aws-sdk "^2.1138.0"
     chalk "^4.1.2"
-    codemaker "^1.57.0"
+    codemaker "^1.59.0"
     constructs "10.1.5"
     git-url-parse "^11.6.0"
     inquirer "^8.2.4"
@@ -323,7 +323,7 @@
     lodash.kebabcase "^4.1.1"
     lodash.upperfirst "^4.3.1"
     read-pkg-up "7.0.1"
-    yargs "^17.4.0"
+    yargs "^17.5.1"
 
 "@guardian/eslint-config-typescript@1.0.1":
   version "1.0.1"
@@ -597,10 +597,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.8.0.tgz#ac1e63aebf8ddaf157d3664911d4a0eb2f013b6f"
-  integrity sha512-XAaqkacs4JiCOKWAX43jhuWcs7IdVMQaYWkeRiD8wan/wlmd7/WlvTFzpNeLOwylbty7uwiPQOFVYHdKj6UPvQ==
+"@oclif/core@1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.8.1.tgz#1783b83b69c2505c070aabff475964cb75fee27b"
+  integrity sha512-6pNQnkL2Uk9SbRUb12BFminLPhrPab1euNzVl1eh+Q7+X8+JGMw8vgKUfQRlGZesmcd+8fByQMZBaoOAEozJsw==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -623,7 +623,7 @@
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
     password-prompt "^1.1.2"
-    semver "^7.3.5"
+    semver "^7.3.7"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
@@ -1019,10 +1019,10 @@ aws-cdk@2.23.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1127.0:
-  version "2.1133.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1133.0.tgz#db530faaa8dbe98503fd600b4e95efdd1c3996c7"
-  integrity sha512-TK7lcDxkrAc15Lmx030u4Wn3P798oxBVs79DBsD8+cZcW5Y8Gvat+evIZpkDoqh8YsfegvlI2jFg4ECQxKYPVA==
+aws-sdk@^2.1138.0:
+  version "2.1138.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1138.0.tgz#5975e028807a327e0900075de6a054fdd939a1f0"
+  integrity sha512-81Bs7qVf1/NrZBDCVIPpynODNN8fvXLdbsK024VITKFjts6DpvWjWPCsRYvEtaksF6uypMx5D02nTYJ8RiXq9w==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1316,10 +1316,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codemaker@^1.57.0:
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.58.0.tgz#6eefc6feff1200956d620649188563531de4c151"
-  integrity sha512-hV9snVkPiXjHKsYpZD7tTb28LHeXCkvZxiwSph9iWTJJP7+fP9s2inDiHdMHF+Nq+o+JLXKWkE2DP5iNOHAtuA==
+codemaker@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.59.0.tgz#71c8c179b2598f7867678d56859495ccbf6d391d"
+  integrity sha512-pVie4lGQgjejvGGcZnhO//9naGRNeHRq96kFrlfQQGABiToLcCy2/UQtAi2qw7FYrPRKqHn2DBR8PcP4avwEMw==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"
@@ -3768,7 +3768,7 @@ saxes@^5.0.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.3.2, semver@^7.3.5, semver@^7.3.6:
+semver@7.x, semver@^7.3.2, semver@^7.3.5, semver@^7.3.6, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -4419,10 +4419,10 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.4.0:
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.0.tgz#2706c5431f8c119002a2b106fc9f58b9bb9097a3"
-  integrity sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==
+yargs@^17.5.1:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
+  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"

--- a/mobile-save-for-later/riff-raff.yaml
+++ b/mobile-save-for-later/riff-raff.yaml
@@ -6,9 +6,15 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: mobile-dist
-      functionNames: [mobile-save-for-later-SAVE-, mobile-save-for-later-FETCH-]
+      functionNames:
+        - mobile-save-for-later-SAVE-
+        - mobile-save-for-later-FETCH-
+        - mobile-save-for-later-SAVE-cdk-
+        - mobile-save-for-later-FETCH-cdk-
       fileName: mobile-save-for-later.jar
       prefixStack: false
+    dependencies:
+      - mobile-save-for-later-cfn
   mobile-save-for-later-cfn:
     type: cloud-formation
     app: mobile-save-for-later


### PR DESCRIPTION
**N.B. this PR depends on https://github.com/guardian/mobile-save-for-later/pull/64**

## What does this change?

We are migrating the `mobile-save-for-later` service from CloudFormation to `@guardian/cdk`. The migration will involve 5 PRs:

1. Add `@guardian/cdk` to repository; update CI & deployment wiring accordingly (https://github.com/guardian/mobile-save-for-later/pull/64)
**2. Provision a new version of the infrastructure using `@guardian/cdk` [this PR]**
3. Move DNS configuration from CloudFormation into `@guardian/cdk` (but continue routing requests to old infrastructure)
4. Update DNS configuration (start routing requests to new infrastructure)
5. Remove old infrastructure

## How to test

I've deployed this to `CODE` to confirm that the deployment works as expected.

I also temporarily updated DNS so that requests were being routed to this new infrastructure. Then I used a debug version of the app to confirm that saving articles/viewing saved articles still works as expected. (I checked the AWS Lambda logs and DynamoDB to confirm that the new Lambdas were being exercised as expected).

## How can we measure success?

We are a step closer to defining all infrastructure using `@guardian/cdk`! 

## Have we considered potential risks?

Yes, the risk is very low at this stage. Although we have provisioned a new API/Lambdas, the old API/Lambdas still serve all of the traffic.