### PR TITLE
Move domain name configuration from CFN to cdk

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,7 +8,7 @@ const app = new App();
 export const codeProps: MobileSaveForLaterProps = {
   stack: "mobile",
   stage: "CODE",
-  certificateId: "b4c2902a-fc80-47a9-88b7-7810b88e7e26",
+  certificateId: "0ee21f37-ec53-437c-b572-3c9d294ab749",
   domainName: "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
   hostedZoneName: "mobile-aws.code.dev-guardianapis.com",
   hostedZoneId: "Z6PRU8YR6TQDK",
@@ -19,7 +19,7 @@ export const codeProps: MobileSaveForLaterProps = {
 export const prodProps: MobileSaveForLaterProps = {
   stack: "mobile",
   stage: "PROD",
-  certificateId: "0ee21f37-ec53-437c-b572-3c9d294ab749",
+  certificateId: "b4c2902a-fc80-47a9-88b7-7810b88e7e26",
   domainName: "mobile-save-for-later.mobile-aws.guardianapis.com",
   hostedZoneName: "mobile-aws.guardianapis.com",
   hostedZoneId: "Z1EYB4AREPXE3B",

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -105,11 +105,18 @@ Object {
     "ApiDomainName": Object {
       "Properties": Object {
         "CertificateArn": Object {
-          "Ref": "CertArn",
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:aws:acm:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/0ee21f37-ec53-437c-b572-3c9d294ab749",
+            ],
+          ],
         },
-        "DomainName": Object {
-          "Fn::Sub": "\${App}.\${HostedZoneName}",
-        },
+        "DomainName": "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -139,17 +146,13 @@ Object {
         "RestApiId": Object {
           "Ref": "SaveForLaterApi",
         },
-        "Stage": Object {
-          "Ref": "Stage",
-        },
+        "Stage": "CODE",
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
     "ApiRoute53": Object {
       "Properties": Object {
-        "HostedZoneId": Object {
-          "Ref": "HostedZoneId",
-        },
+        "HostedZoneId": "Z6PRU8YR6TQDK",
         "RecordSets": Array [
           Object {
             "AliasTarget": Object {
@@ -161,9 +164,7 @@ Object {
               },
               "HostedZoneId": "Z2FDTNDATAQYW2",
             },
-            "Name": Object {
-              "Ref": "ApiDomainName",
-            },
+            "Name": "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
             "Type": "A",
           },
         ],
@@ -1682,11 +1683,18 @@ Object {
     "ApiDomainName": Object {
       "Properties": Object {
         "CertificateArn": Object {
-          "Ref": "CertArn",
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:aws:acm:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b4c2902a-fc80-47a9-88b7-7810b88e7e26",
+            ],
+          ],
         },
-        "DomainName": Object {
-          "Fn::Sub": "\${App}.\${HostedZoneName}",
-        },
+        "DomainName": "mobile-save-for-later.mobile-aws.guardianapis.com",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -1716,17 +1724,13 @@ Object {
         "RestApiId": Object {
           "Ref": "SaveForLaterApi",
         },
-        "Stage": Object {
-          "Ref": "Stage",
-        },
+        "Stage": "PROD",
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
     "ApiRoute53": Object {
       "Properties": Object {
-        "HostedZoneId": Object {
-          "Ref": "HostedZoneId",
-        },
+        "HostedZoneId": "Z1EYB4AREPXE3B",
         "RecordSets": Array [
           Object {
             "AliasTarget": Object {
@@ -1738,9 +1742,7 @@ Object {
               },
               "HostedZoneId": "Z2FDTNDATAQYW2",
             },
-            "Name": Object {
-              "Ref": "ApiDomainName",
-            },
+            "Name": "mobile-save-for-later.mobile-aws.guardianapis.com",
             "Type": "A",
           },
         ],

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -5,8 +5,10 @@ import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
 import type { App } from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
+import { CfnBasePathMapping, CfnDomainName } from "aws-cdk-lib/aws-apigateway";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { CfnRecordSetGroup } from "aws-cdk-lib/aws-route53";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
 export interface MobileSaveForLaterProps extends GuStackProps {
@@ -113,8 +115,41 @@ export class MobileSaveForLater extends GuStack {
       ],
     });
 
+    // N.B. we cannot use GuCertificate here as we deploy to eu-west-1 but the certificate must be created in us-east-1.
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-edge-optimized-custom-domain-name.html
+    const certificateArn = `arn:aws:acm:us-east-1:${this.account}:certificate/${props.certificateId}`;
+
+    const cfnDomainName = new CfnDomainName(this, "ApiDomainName", {
+      domainName: props.domainName,
+      certificateArn,
+    });
+
+    new CfnBasePathMapping(this, "ApiMapping", {
+      domainName: cfnDomainName.ref,
+      // Uncomment the lines below to reroute traffic to the new API Gateway instance
+      // restApiId: saveForLaterApi.api.restApiId,
+      // stage: saveForLaterApi.api.deploymentStage.stageName,
+      restApiId: yamlDefinedResources.getResource("SaveForLaterApi").ref,
+      stage: props.stage,
+    });
+
+    new CfnRecordSetGroup(this, "ApiRoute53", {
+      hostedZoneId: props.hostedZoneId,
+      recordSets: [
+        {
+          name: props.domainName,
+          type: "A",
+          aliasTarget: {
+            dnsName: cfnDomainName.attrDistributionDomainName,
+            // This magical value is taken from the AWS docs:
+            // https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget-1.html#aws-properties-route53-aliastarget-1-properties
+            hostedZoneId: "Z2FDTNDATAQYW2",
+          },
+        },
+      ],
+    });
+
     // TODO:
-    // Move into cdk: DNS configuration
     // Decide whether to port across or leave in CFN: Dynamo Table & Dynamo Throttle CloudWatch Alarms
   }
 }

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -1,16 +1,4 @@
 Resources:
-  ApiRoute53:
-    Type: 'AWS::Route53::RecordSetGroup'
-    Properties:
-      HostedZoneId: !Ref HostedZoneId
-      RecordSets:
-        - AliasTarget:
-            HostedZoneId: Z2FDTNDATAQYW2
-            DNSName: !GetAtt
-              - ApiDomainName
-              - DistributionDomainName
-          Type: A
-          Name: !Ref ApiDomainName
   SaveForLaterWriteThrottleEvents:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
@@ -171,12 +159,6 @@ Resources:
               produces:
                 - application/json
         swagger: '2.0'
-  ApiMapping:
-    Type: 'AWS::ApiGateway::BasePathMapping'
-    Properties:
-      Stage: !Ref Stage
-      RestApiId: !Ref SaveForLaterApi
-      DomainName: !Ref ApiDomainName
   FetchArticlesLambdaPermission:
     Type: 'AWS::Lambda::Permission'
     Properties:
@@ -225,11 +207,6 @@ Resources:
           - StageVariables
           - !Ref Stage
           - TableReadCapacity
-  ApiDomainName:
-    Type: 'AWS::ApiGateway::DomainName'
-    Properties:
-      CertificateArn: !Ref CertArn
-      DomainName: !Sub '${App}.${HostedZoneName}'
   FetchArticlesLambda:
     Type: 'AWS::Lambda::Function'
     Properties:


### PR DESCRIPTION
**N.B. this PR depends on https://github.com/guardian/mobile-save-for-later/pull/64 and https://github.com/guardian/mobile-save-for-later/pull/65.**

## What does this change?

We are migrating the `mobile-save-for-later` service from CloudFormation to `@guardian/cdk`. The migration will involve 5 PRs:

1. Add `@guardian/cdk` to repository; update CI & deployment wiring accordingly (https://github.com/guardian/mobile-save-for-later/pull/64)
2. Provision a new version of the infrastructure using `@guardian/cdk` (https://github.com/guardian/mobile-save-for-later/pull/65)
3. **Move DNS configuration from CloudFormation into `@guardian/cdk` (but continue routing requests to old infrastructure) [this PR]**
4. Update DNS configuration (start routing requests to new infrastructure) (https://github.com/guardian/mobile-save-for-later/pull/67)
5. Remove old infrastructure

## How to test

I've deployed this to CODE and used a debug version of the app to confirm that saving articles/viewing saved articles still works as expected. (I checked the AWS Lambda logs and DynamoDB to confirm that server side code was being exercised as expected).

## How can we measure success?

We are a step closer to defining all infrastructure using `@guardian/cdk`!

## Have we considered potential risks?

Yes, the risk is still low at this stage. Although we have moved some resources from CloudFormation into `@guardian/cdk`, this PR doesn't actually make any DNS changes.