### PR TITLE
Route all traffic to the cdk-defined infrastructure

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -144,9 +144,11 @@ Object {
           "Ref": "ApiDomainName",
         },
         "RestApiId": Object {
-          "Ref": "SaveForLaterApi",
+          "Ref": "RestApi0C43BF4B",
         },
-        "Stage": "CODE",
+        "Stage": Object {
+          "Ref": "RestApiDeploymentStageprod3855DE66",
+        },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
@@ -1722,9 +1724,11 @@ Object {
           "Ref": "ApiDomainName",
         },
         "RestApiId": Object {
-          "Ref": "SaveForLaterApi",
+          "Ref": "RestApi0C43BF4B",
         },
-        "Stage": "PROD",
+        "Stage": Object {
+          "Ref": "RestApiDeploymentStageprod3855DE66",
+        },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -126,11 +126,8 @@ export class MobileSaveForLater extends GuStack {
 
     new CfnBasePathMapping(this, "ApiMapping", {
       domainName: cfnDomainName.ref,
-      // Uncomment the lines below to reroute traffic to the new API Gateway instance
-      // restApiId: saveForLaterApi.api.restApiId,
-      // stage: saveForLaterApi.api.deploymentStage.stageName,
-      restApiId: yamlDefinedResources.getResource("SaveForLaterApi").ref,
-      stage: props.stage,
+      restApiId: saveForLaterApi.api.restApiId,
+      stage: saveForLaterApi.api.deploymentStage.stageName,
     });
 
     new CfnRecordSetGroup(this, "ApiRoute53", {


### PR DESCRIPTION
**N.B. this PR depends on https://github.com/guardian/mobile-save-for-later/pull/64, https://github.com/guardian/mobile-save-for-later/pull/65 and https://github.com/guardian/mobile-save-for-later/pull/66.**

## What does this change?

We are migrating the `mobile-save-for-later` service from CloudFormation to `@guardian/cdk`. The migration will involve 5 PRs:

1. Add `@guardian/cdk` to repository; update CI & deployment wiring accordingly (https://github.com/guardian/mobile-save-for-later/pull/64)
2. Provision a new version of the infrastructure using `@guardian/cdk` (https://github.com/guardian/mobile-save-for-later/pull/65)
3. Move DNS configuration from CloudFormation into `@guardian/cdk` (but continue routing requests to old infrastructure) (https://github.com/guardian/mobile-save-for-later/pull/66)
4. **Update DNS configuration (start routing requests to new infrastructure) [this PR]**
5. Remove old infrastructure

## How to test

I've deployed this to `CODE` and confirmed that traffic is sent to the new API/Lambdas.

When `CODE` was in this state I also used a debug version of the app to confirm that saving articles/viewing saved articles still worked as expected. (I checked the AWS Lambda logs and DynamoDB to confirm that server side code was being exercised as expected).

## How can we measure success?

All traffic for this API will be served by `@guardian/cdk`-defined infrastructure.

## Have we considered potential risks?

This is the riskiest PR in the migration process. When we merge this one, all traffic will be routed to the new infrastructure. If something goes wrong here there will be noticeable impact for apps users. Our rollback strategy (which I've tested) is to revert this PR and route all traffic back to the old infrastructure.

My main concern here is that I don't know how quickly the traffic will be moved over or how well AWS Lambda will cope. This API is powered by Lambdas and the old infrastructure is likely to be scaled at the right level due to a fairly standard (albeit relatively modest) traffic pattern. I don't know if AWS could instantaneously scale to this level or if it will take some time. 

We have a few options here:

1. Contact AWS Support and see if they can 'pre-warm' this service
2. Send some artificial traffic to this API shortly before merging so that it is not completely cold
3. YOLO - merge the PR and hope for the best - we have a good rollback strategy!

Any opinions here are welcome!

**Update**: We are going to go with option 2. 

I have updated the CloudWatch dashboard for this service so that it includes metrics for old infrastructure & `cdk`-defined infrastructure. This will enable us to monitor this service easily during the traffic migration.