### PR TITLE
Set a valid visibility timeout for user deletion queue

### DIFF
--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -100,6 +100,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub UserIdDeleteQueue-${Stage}
+      VisibilityTimeout: 300
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt UserIdDeletionDeadLetterQueue.Arn
         maxReceiveCount: 3


### PR DESCRIPTION
## What does this change?

CloudFormation updates (& therefore deployments) for `mobile-save-for-later-user-deletion` are currently failing due to the following error:

```
Resource handler returned message: "Invalid request provided: Queue visibility timeout: 30 seconds is less than Function timeout: 300 seconds (Service: Lambda, Status Code: 400, Request ID: 18cc81db-b24c-4022-badf-819db90ef4bf, Extended Request ID: null)" (RequestToken: 3b55d589-1a7d-88c6-0cab-75cabeae3b77, HandlerErrorCode: InvalidRequest)
```

A [visibility timeout](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html#cfn-sqs-queue-visibilitytimeout) is intended to prevent the same message being processed multiple times.  The current (invalid) CFN means that the following scenario can occur:

_12:00:00_ - Message is put onto queue with 30 second visibility timeout
_12:00:00_ - Lambda invocation A picks up message
_12:00:30_ - Visibility timeout expires and message becomes available to consumers again
_12:00:30_ - Lambda invocation B picks up the message (Lambda invocation A is still processing)
etc.

As far as I can tell the current version of the CFN is invalid. However, it has been working OK because the validation rules are only run when this resource is created/updated. This hasn't happened in a very long time:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/19384074/172642781-9f2bd0c0-ae98-4028-8c23-9d81dc29dd1e.png">

I believe an update is now being applied due to https://github.com/guardian/riff-raff/pull/687.

## How to test

I've confirmed that this change can be deployed to `CODE`.

## How can we measure success?

1. Deployments will start working again.
4. The risk of duplicate message processing is removed.

## Have we considered potential risks?

Yes, I think this is actually removing some risk / chances of error.

