### PR TITLE
Allow lambdas to be invoked without interacting with downstream services

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
@@ -92,9 +92,13 @@ class LambdaApiGatewayImpl(function: (LambdaRequest => Future[LambdaResponse])) 
     try {
       val response: Future[ApiGatewayLambdaResponse] = objectReadAndClose(inputStream) match {
         case Left(apiLambdaGatewayRequest) =>
-          function(LambdaRequest(apiLambdaGatewayRequest)).map { res =>
-            logger.debug(s"ApiGateway  lamda response: ${res}")
-            ApiGatewayLambdaResponse(res)
+          if (apiLambdaGatewayRequest.queryStringParameters.exists(_.keys.toList.contains("scale-for-cdk-migration"))) {
+            Future.successful(ApiGatewayLambdaResponse(LambdaResponse(200, None)))
+          } else {
+            function(LambdaRequest(apiLambdaGatewayRequest)).map { res =>
+              logger.debug(s"ApiGateway  lamda response: ${res}")
+              ApiGatewayLambdaResponse(res)
+            }
           }
        case Right(_) =>
           logger.debug("Lambda returned error")


### PR DESCRIPTION
## What does this change?

We want to send some artificial traffic to the cdk-version of this service before merging https://github.com/guardian/mobile-save-for-later/pull/67, to ensure that API Gateway/Lambda is not completely cold/scaled down.

However, for these lambdas to work successfully requests must contain a valid Identity token. If we send artificial traffic without these tokens the lambdas will throw errors, which will make it harder to interpret the [dashboard](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=SaveForLater) when we're monitoring the migration. We only need the lambdas to start up to scale up the service, so this simple change allows the lambdas to complete successfully (without doing any useful work) if a special query param is set: `scale-for-cdk-migration`.

As an alternative we could figure out how to send artificial traffic which includes valid tokens and a proper request body, but that seems like more effort for little benefit.

Once the migration is complete we can revert this PR.

## How to test

I've tested this change in `CODE`; if you include the `scale-for-cdk-migration` query param you get a 200 back, if you don't then the API works normally (that is, you can still save/remove articles).

## How can we measure success?

This should allow us to scale up the new service without investing any effort writing code to simulate real requests.

## Have we considered potential risks?

There is a risk of accidentally changing the behaviour for real clients. To mitigate this risk I have 1) tested in `CODE` 2) chosen a relatively obscure name for the query param (it's very unlikely that a real client would send a request with this param key).