### PR TITLE
Revert "Allow lambdas to be invoked without interacting with downstream services"

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/LambdaApiGateway.scala
@@ -92,13 +92,9 @@ class LambdaApiGatewayImpl(function: (LambdaRequest => Future[LambdaResponse])) 
     try {
       val response: Future[ApiGatewayLambdaResponse] = objectReadAndClose(inputStream) match {
         case Left(apiLambdaGatewayRequest) =>
-          if (apiLambdaGatewayRequest.queryStringParameters.exists(_.keys.toList.contains("scale-for-cdk-migration"))) {
-            Future.successful(ApiGatewayLambdaResponse(LambdaResponse(200, None)))
-          } else {
-            function(LambdaRequest(apiLambdaGatewayRequest)).map { res =>
-              logger.debug(s"ApiGateway  lamda response: ${res}")
-              ApiGatewayLambdaResponse(res)
-            }
+          function(LambdaRequest(apiLambdaGatewayRequest)).map { res =>
+            logger.debug(s"ApiGateway  lamda response: ${res}")
+            ApiGatewayLambdaResponse(res)
           }
        case Right(_) =>
           logger.debug("Lambda returned error")


### PR DESCRIPTION
guardian/mobile-save-for-later#70 was only necessary to facilitate the migration to GuCDK. That work is now complete, so  guardian/mobile-save-for-later#70 can be reverted.