### PR TITLE
LIVE-4204: Add 5xx monitoring to the save for later API

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,6 +14,7 @@ export const codeProps: MobileSaveForLaterProps = {
   hostedZoneId: "Z6PRU8YR6TQDK",
   identityApiHost: "https://id.code.dev-guardianapis.com",
   reservedConcurrentExecutions: 1,
+  monitoringConfiguration: { noMonitoring: true }
 };
 
 export const prodProps: MobileSaveForLaterProps = {
@@ -25,6 +26,13 @@ export const prodProps: MobileSaveForLaterProps = {
   hostedZoneId: "Z1EYB4AREPXE3B",
   identityApiHost: "https://id.guardianapis.com",
   reservedConcurrentExecutions: 300,
+  monitoringConfiguration: {
+    snsTopicName: "mobile-server-side",
+    http5xxAlarm: {
+      tolerated5xxPercentage: 1,
+      numberOfMinutesAboveThresholdBeforeAlarm: 1,
+    },
+  },
 };
 
 new MobileSaveForLater(app, "MobileSaveForLater-CODE", codeProps);

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,7 +14,7 @@ export const codeProps: MobileSaveForLaterProps = {
   hostedZoneId: "Z6PRU8YR6TQDK",
   identityApiHost: "https://id.code.dev-guardianapis.com",
   reservedConcurrentExecutions: 1,
-  monitoringConfiguration: { noMonitoring: true }
+  monitoringConfiguration: { noMonitoring: true },
 };
 
 export const prodProps: MobileSaveForLaterProps = {

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -130,7 +130,7 @@ Object {
         "AlarmDescription": "mobile-save-for-later exceeded 1% error rate",
         "AlarmName": "High 5XX error % from mobile-save-for-later (ApiGateway) in CODE",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 3,
+        "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -683,84 +683,6 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
-    },
-    "SaveForLaterReadThrottleEvents": Object {
-      "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "StageVariables",
-            Object {
-              "Ref": "Stage",
-            },
-            "AlarmActionsEnabled",
-          ],
-        },
-        "AlarmActions": Array [
-          Object {
-            "Ref": "DynamoNotificationTopic",
-          },
-        ],
-        "AlarmName": Object {
-          "Fn::Sub": "\${App}-\${Stage}-articles-ReadCapacityUnitsLimit-BasicAlarm",
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "TableName",
-            "Value": Object {
-              "Ref": "SaveForLaterDynamoTable",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "ReadThrottleEvents",
-        "Namespace": "AWS/DynamoDB",
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-        "Unit": "Count",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "SaveForLaterWriteThrottleEvents": Object {
-      "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "StageVariables",
-            Object {
-              "Ref": "Stage",
-            },
-            "AlarmActionsEnabled",
-          ],
-        },
-        "AlarmActions": Array [
-          Object {
-            "Ref": "DynamoNotificationTopic",
-          },
-        ],
-        "AlarmName": Object {
-          "Fn::Sub": "\${App}-\${Stage}-articles-WriteCapacityUnitsLimit-BasicAlarm",
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "TableName",
-            "Value": Object {
-              "Ref": "SaveForLaterDynamoTable",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "WriteThrottleEvents",
-        "Namespace": "AWS/DynamoDB",
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-        "Unit": "Count",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "fetcharticleslambda4E2BF026": Object {
       "DependsOn": Array [
@@ -1352,7 +1274,7 @@ Object {
         "AlarmDescription": "mobile-save-for-later exceeded 1% error rate",
         "AlarmName": "High 5XX error % from mobile-save-for-later (ApiGateway) in PROD",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 3,
+        "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -1905,84 +1827,6 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
-    },
-    "SaveForLaterReadThrottleEvents": Object {
-      "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "StageVariables",
-            Object {
-              "Ref": "Stage",
-            },
-            "AlarmActionsEnabled",
-          ],
-        },
-        "AlarmActions": Array [
-          Object {
-            "Ref": "DynamoNotificationTopic",
-          },
-        ],
-        "AlarmName": Object {
-          "Fn::Sub": "\${App}-\${Stage}-articles-ReadCapacityUnitsLimit-BasicAlarm",
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "TableName",
-            "Value": Object {
-              "Ref": "SaveForLaterDynamoTable",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "ReadThrottleEvents",
-        "Namespace": "AWS/DynamoDB",
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-        "Unit": "Count",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "SaveForLaterWriteThrottleEvents": Object {
-      "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "StageVariables",
-            Object {
-              "Ref": "Stage",
-            },
-            "AlarmActionsEnabled",
-          ],
-        },
-        "AlarmActions": Array [
-          Object {
-            "Ref": "DynamoNotificationTopic",
-          },
-        ],
-        "AlarmName": Object {
-          "Fn::Sub": "\${App}-\${Stage}-articles-WriteCapacityUnitsLimit-BasicAlarm",
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "TableName",
-            "Value": Object {
-              "Ref": "SaveForLaterDynamoTable",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "WriteThrottleEvents",
-        "Namespace": "AWS/DynamoDB",
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-        "Unit": "Count",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "fetcharticleslambda4E2BF026": Object {
       "DependsOn": Array [

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -106,6 +106,79 @@ Object {
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "ApiGatewayHigh5xxPercentageAlarmMobilesaveforlater7A59CCCF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "mobile-save-for-later exceeded 1% error rate",
+        "AlarmName": "High 5XX error % from mobile-save-for-later (ApiGateway) in CODE",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for mobile-save-for-later",
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "mobile-save-for-later-api-CODE",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "mobile-save-for-later-api-CODE",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ApiMapping": Object {
       "Properties": Object {
         "DomainName": Object {
@@ -1254,6 +1327,79 @@ Object {
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "ApiGatewayHigh5xxPercentageAlarmMobilesaveforlater7A59CCCF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "mobile-save-for-later exceeded 1% error rate",
+        "AlarmName": "High 5XX error % from mobile-save-for-later (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for mobile-save-for-later",
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "mobile-save-for-later-api-PROD",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "mobile-save-for-later-api-PROD",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "ApiMapping": Object {
       "Properties": Object {

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -6,12 +6,10 @@ Object {
   "Mappings": Object {
     "StageVariables": Object {
       "CODE": Object {
-        "AlarmActionsEnabled": false,
         "TableReadCapacity": 1,
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "AlarmActionsEnabled": true,
         "TableReadCapacity": 200,
         "TableWriteCapacity": 75,
       },
@@ -105,79 +103,6 @@ Object {
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
-    },
-    "ApiGatewayHigh5xxPercentageAlarmMobilesaveforlater7A59CCCF": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:aws:sns:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                Object {
-                  "Ref": "AWS::AccountId",
-                },
-                ":arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "mobile-save-for-later exceeded 1% error rate",
-        "AlarmName": "High 5XX error % from mobile-save-for-later (ApiGateway) in CODE",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": Array [
-          Object {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": "% of 5XX responses served for mobile-save-for-later",
-          },
-          Object {
-            "Id": "m1",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "mobile-save-for-later-api-CODE",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "m2",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "mobile-save-for-later-api-CODE",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "SampleCount",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "ApiMapping": Object {
       "Properties": Object {
@@ -1150,12 +1075,10 @@ Object {
   "Mappings": Object {
     "StageVariables": Object {
       "CODE": Object {
-        "AlarmActionsEnabled": false,
         "TableReadCapacity": 1,
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "AlarmActionsEnabled": true,
         "TableReadCapacity": 200,
         "TableWriteCapacity": 75,
       },
@@ -1266,7 +1189,7 @@ Object {
                 Object {
                   "Ref": "AWS::AccountId",
                 },
-                ":arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
+                ":mobile-server-side",
               ],
             ],
           },

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -150,8 +150,5 @@ export class MobileSaveForLater extends GuStack {
         },
       ],
     });
-
-    // TODO:
-    // Decide whether to port across or leave in CFN: Dynamo Table & Dynamo Throttle CloudWatch Alarms
   }
 }

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -99,7 +99,13 @@ export class MobileSaveForLater extends GuStack {
     const saveForLaterApi = new GuApiGatewayWithLambdaByPath(this, {
       app,
       restApiName: `${app}-api-${this.stage}`,
-      monitoringConfiguration: { noMonitoring: true }, //TODO: configure monitoring (this is not setup in current CFN)
+      monitoringConfiguration: {
+        snsTopicName: "arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
+        http5xxAlarm: {
+          tolerated5xxPercentage: 1,
+          numberOfMinutesAboveThresholdBeforeAlarm: 3,
+        },
+      },
       targets: [
         {
           path: "/syncedPrefs/me/savedArticles",

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { GuApiGatewayWithLambdaByPath } from "@guardian/cdk";
+import {ApiGatewayAlarms, GuApiGatewayWithLambdaByPath} from "@guardian/cdk";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
@@ -10,6 +10,7 @@ import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { CfnRecordSetGroup } from "aws-cdk-lib/aws-route53";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+import { NoMonitoring } from "@guardian/cdk/lib/constructs/cloudwatch";
 
 export interface MobileSaveForLaterProps extends GuStackProps {
   certificateId: string;
@@ -18,6 +19,7 @@ export interface MobileSaveForLaterProps extends GuStackProps {
   hostedZoneId: string;
   identityApiHost: string;
   reservedConcurrentExecutions: number;
+  monitoringConfiguration: NoMonitoring | ApiGatewayAlarms;
 }
 
 export class MobileSaveForLater extends GuStack {
@@ -99,13 +101,7 @@ export class MobileSaveForLater extends GuStack {
     const saveForLaterApi = new GuApiGatewayWithLambdaByPath(this, {
       app,
       restApiName: `${app}-api-${this.stage}`,
-      monitoringConfiguration: {
-        snsTopicName: "arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
-        http5xxAlarm: {
-          tolerated5xxPercentage: 1,
-          numberOfMinutesAboveThresholdBeforeAlarm: 1,
-        },
-      },
+      monitoringConfiguration: props.monitoringConfiguration,
       targets: [
         {
           path: "/syncedPrefs/me/savedArticles",

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -1,5 +1,7 @@
 import { join } from "path";
-import {ApiGatewayAlarms, GuApiGatewayWithLambdaByPath} from "@guardian/cdk";
+import { GuApiGatewayWithLambdaByPath } from "@guardian/cdk";
+import type { ApiGatewayAlarms } from "@guardian/cdk";
+import type { NoMonitoring } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
@@ -10,7 +12,6 @@ import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { CfnRecordSetGroup } from "aws-cdk-lib/aws-route53";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
-import { NoMonitoring } from "@guardian/cdk/lib/constructs/cloudwatch";
 
 export interface MobileSaveForLaterProps extends GuStackProps {
   certificateId: string;

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -103,7 +103,7 @@ export class MobileSaveForLater extends GuStack {
         snsTopicName: "arn:aws:sns:eu-west-1:201359054765:mobile-server-side",
         http5xxAlarm: {
           tolerated5xxPercentage: 1,
-          numberOfMinutesAboveThresholdBeforeAlarm: 3,
+          numberOfMinutesAboveThresholdBeforeAlarm: 1,
         },
       },
       targets: [

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -1,48 +1,4 @@
 Resources:
-  SaveForLaterWriteThrottleEvents:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      EvaluationPeriods: 1
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: TableName
-          Value: !Ref SaveForLaterDynamoTable
-      AlarmActions:
-        - !Ref DynamoNotificationTopic
-      Namespace: AWS/DynamoDB
-      Period: 60
-      ComparisonOperator: GreaterThanThreshold
-      AlarmName: !Sub '${App}-${Stage}-articles-WriteCapacityUnitsLimit-BasicAlarm'
-      ActionsEnabled: !FindInMap
-        - StageVariables
-        - !Ref Stage
-        - AlarmActionsEnabled
-      Statistic: Sum
-      Threshold: 0
-      Unit: Count
-      MetricName: WriteThrottleEvents
-  SaveForLaterReadThrottleEvents:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      EvaluationPeriods: 1
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: TableName
-          Value: !Ref SaveForLaterDynamoTable
-      AlarmActions:
-        - !Ref DynamoNotificationTopic
-      Namespace: AWS/DynamoDB
-      Period: 60
-      ComparisonOperator: GreaterThanThreshold
-      AlarmName: !Sub '${App}-${Stage}-articles-ReadCapacityUnitsLimit-BasicAlarm'
-      ActionsEnabled: !FindInMap
-        - StageVariables
-        - !Ref Stage
-        - AlarmActionsEnabled
-      Statistic: Sum
-      Threshold: 0
-      Unit: Count
-      MetricName: ReadThrottleEvents
   SaveForLaterDynamoTable:
     DeletionPolicy: Retain
     Type: 'AWS::DynamoDB::Table'

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -37,10 +37,8 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
-      AlarmActionsEnabled: false
       TableReadCapacity: 1
       TableWriteCapacity: 1
     PROD:
-      AlarmActionsEnabled: true
       TableReadCapacity: 200
       TableWriteCapacity: 75


### PR DESCRIPTION
## What does this change?
Adds some configuration to the CDK template, to allow monitoring for 5XX errors. Our read and write throttle alarms are triggered after 1 data point so I thought it would be good to keep to this pattern, and 1% error rate. 1 minute was also the pattern used in the throttle events so have matched with that, but i am open to suggestions.

As commented in this PR: https://github.com/guardian/mobile-save-for-later/pull/65#discussion_r885325721 - I think this means we can just have 5XX error monitoring and not migrate across alarms for throttling. So have removed them from the YAML template.

## How can we measure success?
We successfully get notified about errors in our save for later service
