### PR TITLE
Increase capacity for table reads

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -10,7 +10,7 @@ Object {
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 200,
+        "TableReadCapacity": 400,
         "TableWriteCapacity": 75,
       },
     },
@@ -1079,7 +1079,7 @@ Object {
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 200,
+        "TableReadCapacity": 400,
         "TableWriteCapacity": 75,
       },
     },

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -40,5 +40,5 @@ Mappings:
       TableReadCapacity: 1
       TableWriteCapacity: 1
     PROD:
-      TableReadCapacity: 200
+      TableReadCapacity: 400
       TableWriteCapacity: 75


### PR DESCRIPTION
Temporarily increase our table read capacity to hopefully ease traffic spikes on the save for later service.

## What does this change?

- Bump the reads from 200 to 400

## How can we measure success?

- 5XX error alarms ease off