### PR TITLE
Reduce table read capacity back to 200

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -10,7 +10,7 @@ Object {
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 400,
+        "TableReadCapacity": 200,
         "TableWriteCapacity": 75,
       },
     },
@@ -1079,7 +1079,7 @@ Object {
         "TableWriteCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 400,
+        "TableReadCapacity": 200,
         "TableWriteCapacity": 75,
       },
     },

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -40,5 +40,5 @@ Mappings:
       TableReadCapacity: 1
       TableWriteCapacity: 1
     PROD:
-      TableReadCapacity: 400
+      TableReadCapacity: 200
       TableWriteCapacity: 75


### PR DESCRIPTION
## What does this change?
Now the news of the Queens death has calmed we can reduce the read capacity of the save for later table back to 200.