### PR TITLE
Bump okhttp jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,7 @@ def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = comm
   assembly / assemblyMergeStrategy := {
     case "META-INF/MANIFEST.MF" => MergeStrategy.discard
     case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => new MergeFilesStrategy
-    case x =>
-      val oldStrategy = (assembly / assemblyMergeStrategy).value
-      oldStrategy(x)
+    case _ => MergeStrategy.first
   },
   assemblyJarName := s"${name.value}.jar",
   riffRaffPackageType := assembly.value,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -5930,9 +5930,9 @@
       }
     },
     "node_modules/parse-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
-      "integrity": "sha512-cYyojeX7yIIwuJzledIHeLUBVJ6COVLeT4eF+2P6aKVzwvgKQPndCBv3+yQ7pcWjqToYwaligxzSYNNmGoMAvw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.5.tgz",
+      "integrity": "sha512-e35AeLTSIlkw/5GFq70IN7po8fmDUjpDPY1rIK+VubRfsUvBonjQ+PBZG+vWMACnQSmNlvl524IucoDmcioMxA==",
       "dev": true,
       "dependencies": {
         "is-ssh": "^1.3.0",
@@ -12150,9 +12150,9 @@
       }
     },
     "parse-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
-      "integrity": "sha512-cYyojeX7yIIwuJzledIHeLUBVJ6COVLeT4eF+2P6aKVzwvgKQPndCBv3+yQ7pcWjqToYwaligxzSYNNmGoMAvw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.5.tgz",
+      "integrity": "sha512-e35AeLTSIlkw/5GFq70IN7po8fmDUjpDPY1rIK+VubRfsUvBonjQ+PBZG+vWMACnQSmNlvl524IucoDmcioMxA==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdkVersion = "1.11.412"
   val log4j2Version = "2.17.1"
-  val jacksonVersion = "2.9.4"
+  val jacksonVersion = "2.13.4"
   val specsVersion = "4.0.3"
 
 
@@ -22,7 +22,7 @@ object Dependencies {
   val log4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j2Version
   val commonsIo = "commons-io" % "commons-io" % "2.6"
   val scanamo = "com.gu" %% "scanamo" % "1.0.0-M6"
-  val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
+  val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.9.2"
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"


### PR DESCRIPTION
## What does this change?

This PR bumps the following dependencies to fix the snyk vulnerabilities and one dependabot alert:
1) Jackson library 
2) okhttp library
3) parse-url 

## How to test

We passed all the unit tests.

