### PR TITLE
Remove bucket parameter from riff-raff config

### DIFF
--- a/mobile-save-for-later-user-deletion/riff-raff.yaml
+++ b/mobile-save-for-later-user-deletion/riff-raff.yaml
@@ -5,7 +5,6 @@ deployments:
   mobile-save-for-later-user-deletion:
     type: aws-lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-save-for-later-user-deletion-]
       fileName: mobile-save-for-later-user-deletion.jar
       prefixStack: false

--- a/mobile-save-for-later/riff-raff.yaml
+++ b/mobile-save-for-later/riff-raff.yaml
@@ -5,7 +5,6 @@ deployments:
   mobile-save-for-later:
     type: aws-lambda
     parameters:
-      bucket: mobile-dist
       functionNames:
         - mobile-save-for-later-SAVE-cdk-
         - mobile-save-for-later-FETCH-cdk-


### PR DESCRIPTION
## What does this change?

From DevX: "Our [recommendations](https://github.com/guardian/recommendations/blob/main/github.md#repository-contents) for repository content suggests not committing S3 bucket names into public repositories."

We can update the riff raff config to remove the s3 bucket name by using the `bucketSsmLookup` property. Given that the deploy bucket already matches the value in `/account/services/artifact.bucket` we don't need to specify an additional ssm param for the bucket name. 

Additionally, `bucketSsmLookup` now defaults to `true`, so this isn't needed either, we can simply omit the `bucket` parameter.

