### PR TITLE
Fix failing user deletion deploy

### DIFF
--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -113,11 +113,7 @@ Resources:
   UserDeletionAlarmTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !Sub UserDeletionQueueAlert-${Stage}
-      Subscription:
-        - Endpoint: mobile.server.side@theguardian.com
-          Protocol: email
-
+      TopicName: mobile-server-side
 
   UserDeletionQueueDepthAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -125,9 +125,9 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Threshold: 10
       AlarmActions:
-        - Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       InsufficientDataActions:
-        - Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
           
   UserDeletionLambda:
     Type: AWS::Lambda::Function

--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -110,11 +110,6 @@ Resources:
     Properties:
       QueueName: !Sub UserIdDeleteQueue-deadletter-${Stage}
 
-  UserDeletionAlarmTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      TopicName: mobile-server-side
-
   UserDeletionQueueDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -130,9 +125,9 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Threshold: 10
       AlarmActions:
-        - Ref: UserDeletionAlarmTopic
+        - Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       InsufficientDataActions:
-        - Ref: UserDeletionAlarmTopic
+        - Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
           
   UserDeletionLambda:
     Type: AWS::Lambda::Function

--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -128,6 +128,8 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       InsufficientDataActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
           
   UserDeletionLambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
## What does this change?

The last continuous deploys of the save-for-later-user-deletion stack have failed:

<img width="1178" alt="Screenshot 2022-12-20 at 10 39 19" src="https://user-images.githubusercontent.com/45561419/208647507-caf412a4-637a-4fe8-9efa-b592d22f8cf8.png">

Looking at the corresponding resources we can see that the topic associated with the queue depth alarm has been deleted from the stack:

![image](https://user-images.githubusercontent.com/45561419/208647663-efd5dd8d-dd95-44b7-8dff-3d341b79e304.png)

To enable the deploy to be successful it's suggested that we:
- remove all references to the now deleted alarm topics
- use instead the generic `mobile-server-side` alarm topic

This change will involve updating resources, it will need to be deployed via riff raff using the "Dangerous" update strategy.

## How to test

After a successful deploy to CODE:
- manually disable the lambda trigger from messages landing on queue `UserIdDeleteQueue-CODE`
- manually put 11 messages onto the queue

Expect to receive an alert in the server alerts google space.

<img width="858" alt="Screenshot 2022-12-20 at 10 43 37" src="https://user-images.githubusercontent.com/45561419/208648305-4498f90f-705a-493a-b4ec-5f87fd90d9f1.png">
