### PR TITLE
Adds the ability to authenticate with Identity-issued browser cookie

### DIFF
--- a/lamba-locally.md
+++ b/lamba-locally.md
@@ -1,0 +1,32 @@
+### Running a lambda locally (WIP)
+
+
+
+1. Get and modify the cloudformation definition
+- Get a definition of the lambda from by clicking `export function` and choosing `Download AWS SAM file` on the lambda aws console
+- Copy this and rename to `template.yaml` and put in the root of the project
+- Delete the lines that say:
+  `RuntimePolicy:
+      UpdateRuntimeOn: Auto`
+- Update the param `CodeUri` with the path to the jar that is outputted as a result of running riffRaffPackageType
+
+_(Repeat steps 2 & 3 everytime you make local code changes)_
+
+2. Build a jar of the project by running:
+- `sbt "project mobile-save-for-later" riffRaffPackageType`
+
+3. Run the lambda service (--debug not needed for printlns)
+- sam local start-lambda 
+
+
+4. Execute a function in a new terminal window:
+- Create a payload.json file with your Request data
+- 
+  aws lambda invoke --function-name "mobilesaveforlaterFETCHcdkCODE" \
+  --endpoint-url "http://127.0.0.1:3001" \
+  --cli-binary-format raw-in-base64-out \
+  --payload file://payload.json \
+  output.txt \
+  --no-verify-ssl --profile mobile --region eu-west-1
+
+docs: https://awscli.amazonaws.com/v2/documentation/api/latest/reference

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -51,7 +51,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
         .add("Authorization", auth.auth)
         .build()
       case cookie: IdentityHeadersWithCookie => new Headers.Builder()
-        .add("X-GU-ID-Client-Access-Token", identityHeaders.accessToken)
+        .add("X-GU-ID-Client-Access-Token", cookie.accessToken)
         .add("X-GU-ID-FOWARDED-SC-GU-U", cookie.scGuUCookie)
         .build()
     }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/AuthHeaderParser.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/AuthHeaderParser.scala
@@ -1,14 +1,22 @@
 package com.gu.sfl.lib
 
-import com.gu.sfl.identity.IdentityHeader
+import com.gu.sfl.identity.{IdentityHeadersWithAuth, IdentityHeadersWithCookie, IdentityHeaders}
 import com.gu.sfl.util.HeaderNames.Identity
 
 trait AuthHeaderParser {
-    def getIdentityHeaders(headers: Map[String, String]) : Option[IdentityHeader] = {
+    def getIdentityHeaders(headers: Map[String, String]) : Option[IdentityHeaders] = {
       //Ios sends 'authorisation' whereas android 'Authorisation'
-      for {
+      val authOpt = for {
         auth <- headers.get(Identity.auth)
         isOauth = headers.contains(Identity.isOauth)
-      } yield (IdentityHeader(auth = auth, isOauth = isOauth))
+      } yield IdentityHeadersWithAuth(auth = auth, isOauth = isOauth)
+
+      val cookieOpt = headers.get("cookie") match {
+        case Some("") => None
+        case Some(scGuU) => Some(IdentityHeadersWithCookie(scGuUCookie = scGuU))
+        case None => None
+      }
+
+      if (authOpt.isDefined) { authOpt } else { cookieOpt }
     }
 }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/AuthHeaderParser.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/AuthHeaderParser.scala
@@ -11,12 +11,15 @@ trait AuthHeaderParser {
         isOauth = headers.contains(Identity.isOauth)
       } yield IdentityHeadersWithAuth(auth = auth, isOauth = isOauth)
 
-      val cookieOpt = headers.get("cookie") match {
-        case Some("") => None
-        case Some(scGuU) => Some(IdentityHeadersWithCookie(scGuUCookie = scGuU))
-        case None => None
-      }
+      val cookieOpt = for {
+        scGuUCookie <- headers.get(Identity.SCGUUCookie)
+        clientAccessToken <- headers.get(Identity.accessToken)
+      } yield IdentityHeadersWithCookie(scGuUCookie = scGuUCookie, accessToken = clientAccessToken)
 
-      if (authOpt.isDefined) { authOpt } else { cookieOpt }
+      if (authOpt.isDefined) {
+        authOpt
+      } else {
+        cookieOpt
+      }
     }
 }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -27,7 +27,7 @@ class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMer
             logger.debug(s"Storing ${savedArticles.numberOfArticles} articles for user $userId")
             Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
           case Success(_) =>
-            logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")
+//            logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")
             Future.successful(Left(new UserNotFoundError("Could not retrieve a user id")))
           case Failure(OktaValidationException(e)) =>
             logger.debug(s"Error retrieving userId from okta oauth token")

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/savedarticles/UpdateSavedArticles.scala
@@ -4,7 +4,7 @@ import com.gu.identity.auth.OktaValidationException
 import com.gu.sfl.Logging
 import com.gu.sfl.exception.{IdentityServiceError, MissingAccessTokenError, OktaOauthValidationError, SaveForLaterError, UserNotFoundError}
 import com.gu.sfl.identity.AccessScope.updateSelf
-import com.gu.sfl.identity.IdentityService
+import com.gu.sfl.identity.{IdentityHeadersWithAuth, IdentityService}
 import com.gu.sfl.lib.{AuthHeaderParser, SavedArticlesMerger}
 import com.gu.sfl.model.SavedArticles
 
@@ -23,15 +23,18 @@ class UpdateSavedArticlesImpl(identityService: IdentityService, savedArticlesMer
     } yield {
       val eventualMaybeString = identityService.userFromRequest(identityHeaders, List(updateSelf))
       eventualMaybeString transformWith {
-          case Success(Some(userId)) =>
-            logger.debug(s"Storing ${savedArticles.numberOfArticles} articles for user $userId")
-            Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
-          case Success(_) =>
-//            logger.debug(s"Could not retrieve a user id for token: ${identityHeaders.auth}")
-            Future.successful(Left(new UserNotFoundError("Could not retrieve a user id")))
-          case Failure(OktaValidationException(e)) =>
-            logger.debug(s"Error retrieving userId from okta oauth token")
-            Future.successful(Left(OktaOauthValidationError(e.message, e)))
+        case Success(Some(userId)) =>
+          logger.debug(s"Storing ${savedArticles.numberOfArticles} articles for user $userId")
+          Future.successful(savedArticlesMerger.updateWithRetryAndMerge(userId, savedArticles))
+        case Success(_) =>
+          identityHeaders match {
+            case auth: IdentityHeadersWithAuth => logger.debug(s"Could not retrieve a user id for token: ${identityHeaders}")
+            case _ => logger.debug(s"Could not retrieve a user id for submitted header cookies")
+          }
+          Future.successful(Left(new UserNotFoundError("Could not retrieve a user id")))
+        case Failure(OktaValidationException(e)) =>
+          logger.debug(s"Error retrieving userId from okta oauth token")
+          Future.successful(Left(OktaOauthValidationError(e.message, e)))
           case Failure(_) =>
             logger.debug(s"Error retrieving userId for: token: ${identityHeaders.accessToken}")
             Future.successful(Left(new IdentityServiceError("Could not retrieve a user from the id api")))

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/util/HeaderNames.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/util/HeaderNames.scala
@@ -3,8 +3,9 @@ package com.gu.sfl.util
 object HeaderNames {
 
   object Identity {
-    val accessToken = "X-GU-ID-Client-Access-Token"
+    val accessToken = "x-gu-id-client-access-token"
     val auth = "authorization"
     val isOauth = "x-gu-is-oauth"
+    val SCGUUCookie = "x-gu-id-fowarded-sc-gu-u"
   }
 }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -21,20 +21,20 @@ import scala.util.{Failure, Success}
 
 class IdentityServiceSpec extends Specification with ThrownMessages with Mockito {
 
-  val identityHeaders = IdentityHeadersWithAuth("auth")
-  val identityHeadersWithCookie = IdentityHeadersWithCookie("cookie")
-  val identityOauthHeaders = IdentityHeadersWithAuth("Bearer authorization_header", isOauth = true)
-  val identityOauthHeadersWithCookie = IdentityHeadersWithCookie("Bearer authorization_header", isOauth = true)
+  val identityHeaders = IdentityHeadersWithAuth("auth", "Bearer authorization_header")
+  val identityHeadersWithCookie = IdentityHeadersWithCookie("cookie", "Bearer authorization_header")
+  val identityOauthHeaders = IdentityHeadersWithAuth("Auth", "Bearer authorization_header", isOauth = true)
+  val identityOauthHeadersWithCookie = IdentityHeadersWithCookie("cookie", "Bearer authorization_header", isOauth = true)
 
   "the identity service using Identity API" should {
     "return the user id when the identity api received expected authorisation headers" in new MockHttpRequestScope {
-      val futureUserId = identityService.userFromRequest(identityHeadersWithCookie, any())
+      val futureUserId = identityService.userFromRequest(identityHeaders, any())
       Await.result(futureUserId, Duration.Inf) mustEqual (Some("1234"))
     }
 
     // todo cover all unhappy paths?
     "return the user id when the identity api received expected authorisation cookie" in new MockHttpRequestScope {
-      val futureUserId = identityService.userFromRequest(identityHeaders, any())
+      val futureUserId = identityService.userFromRequest(identityHeadersWithCookie, any())
       Await.result(futureUserId, Duration.Inf) mustEqual (Some("1234"))
     }
 

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/lib/AuthHeaderParserSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/lib/AuthHeaderParserSpec.scala
@@ -18,13 +18,9 @@ class AuthHeaderParserSpec extends Specification {
     }
 
     "Get the scGuU Cookie from the cookie header" in new AuthHeaderScope {
-      val headers = Map("cookie" -> "SC_GU_U=somecookie")
+      val headers = Map("x-gu-id-fowarded-sc-gu-u" -> "somecookie",
+        "x-gu-id-client-access-token" -> "Bearer token")
       parser.getIdentityHeaders(headers) mustEqual (expectedIdentityCookies)
-    }
-
-    "No scGuU Cookie returns none" in new AuthHeaderScope {
-      val headers = Map("cookie" -> "")
-      parser.getIdentityHeaders(headers) mustEqual (None)
     }
 
     "Get 'isOauth' flag if header is set" in new AuthHeaderScope {
@@ -37,7 +33,7 @@ class AuthHeaderParserSpec extends Specification {
   trait AuthHeaderScope extends Scope {
     val parser = new AuthHeaderParser {}
     val expectedIdentityHeaders = Some(IdentityHeadersWithAuth("someAuth"))
-    val expectedIdentityCookies = Some(IdentityHeadersWithCookie("SC_GU_U=somecookie"))
+    val expectedIdentityCookies = Some(IdentityHeadersWithCookie("somecookie", "Bearer token"))
     val expectedOauthHeaders = Some(IdentityHeadersWithAuth("someAuth", isOauth = true))
 
   }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/lib/AuthHeaderParserSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/lib/AuthHeaderParserSpec.scala
@@ -1,20 +1,30 @@
 package com.gu.sfl.lib
 
-import com.gu.sfl.identity.IdentityHeader
+import com.gu.sfl.identity.{IdentityHeadersWithAuth, IdentityHeadersWithCookie}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 class AuthHeaderParserSpec extends Specification {
-  
+
   "parse" should {
     "Get the auth from a header" in new AuthHeaderScope {
-       val headers = Map("authorization" -> "someAuth")
-       parser.getIdentityHeaders(headers) mustEqual(expectedIdentityHeaders)
+      val headers = Map("authorization" -> "someAuth")
+      parser.getIdentityHeaders(headers) mustEqual (expectedIdentityHeaders)
     }
 
-    "No auth header returns none" in new AuthHeaderScope  {
+    "No auth header returns none" in new AuthHeaderScope {
       val headers = Map("tosh" -> "someTosh")
-      parser.getIdentityHeaders(headers) mustEqual(None)
+      parser.getIdentityHeaders(headers) mustEqual (None)
+    }
+
+    "Get the scGuU Cookie from the cookie header" in new AuthHeaderScope {
+      val headers = Map("cookie" -> "SC_GU_U=somecookie")
+      parser.getIdentityHeaders(headers) mustEqual (expectedIdentityCookies)
+    }
+
+    "No scGuU Cookie returns none" in new AuthHeaderScope {
+      val headers = Map("cookie" -> "")
+      parser.getIdentityHeaders(headers) mustEqual (None)
     }
 
     "Get 'isOauth' flag if header is set" in new AuthHeaderScope {
@@ -25,9 +35,11 @@ class AuthHeaderParserSpec extends Specification {
   }
 
   trait AuthHeaderScope extends Scope {
-     val parser = new AuthHeaderParser {}
-     val expectedIdentityHeaders = Some(IdentityHeader("someAuth", "Bearer application_token"))
-     val expectedOauthHeaders = Some(IdentityHeader("someAuth", "Bearer application_token", true))
-  }
+    val parser = new AuthHeaderParser {}
+    val expectedIdentityHeaders = Some(IdentityHeadersWithAuth("someAuth"))
+    val expectedIdentityCookies = Some(IdentityHeadersWithCookie("SC_GU_U=somecookie"))
+    val expectedOauthHeaders = Some(IdentityHeadersWithAuth("someAuth", isOauth = true))
 
+  }
 }
+


### PR DESCRIPTION
## What does this change?

Refactors the parsing of the authorization request headers to also grab the cookie header string and send those along if present for authorisation via Identity.

This is required to unblock adding Saved Articles mvp to Manage My Account. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
