### PR TITLE
Update identity-auth-core dependency to 4.12

### DIFF
--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -59,13 +59,14 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
 
   "the identity service using OAuth / Okta" should {
     "return the user id (identityId) from the oauth access token claims" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), DefaultAccessClaimsParser) returns Right(DefaultAccessClaims("email", "1234", Some("username")))
+      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken[DefaultAccessClaims](any(), any(), any()) returns
+        Right(DefaultAccessClaims("email", "1234", Some("username")))
       val futureUserId = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       Await.result(futureUserId, Duration.Inf) mustEqual (Some("1234"))
     }
 
     "return future failed when the oauth access token is invalid" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), DefaultAccessClaimsParser) returns Left(InvalidOrExpiredToken)
+      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), any()) returns Left(InvalidOrExpiredToken)
       val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 
@@ -76,7 +77,7 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     "return future failed when the oauth access token has missing claims" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), DefaultAccessClaimsParser) returns Left(MissingRequiredClaim("claim_name"))
+      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), any()) returns Left(MissingRequiredClaim("claim_name"))
       val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 
@@ -87,7 +88,7 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     "return future failed when the oauth access token has missing scope" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), DefaultAccessClaimsParser) returns Left(MissingRequiredScope(List(readSelf)))
+      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(any(), any(), any()) returns Left(MissingRequiredScope(List(readSelf)))
       val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(updateSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -1,6 +1,15 @@
 package com.gu.sfl.identity
 
-import com.gu.identity.auth.{AccessToken, DefaultAccessClaims, DefaultAccessClaimsParser, InvalidOrExpiredToken, MissingRequiredClaim, MissingRequiredScope, OktaLocalAccessTokenValidator, OktaValidationException}
+import com.gu.identity.auth.{
+  AccessToken,
+  DefaultAccessClaims,
+  DefaultAccessClaimsParser,
+  InvalidOrExpiredToken,
+  MissingRequiredClaim,
+  MissingRequiredScope,
+  OktaLocalAccessTokenValidator,
+  OktaValidationException
+}
 
 import java.io.IOException
 import com.gu.sfl.exception.IdentityApiRequestError
@@ -18,12 +27,18 @@ import com.gu.sfl.lib.Parallelism.largeGlobalExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-
-class IdentityServiceSpec extends Specification with ThrownMessages with Mockito {
+class IdentityServiceSpec
+    extends Specification
+    with ThrownMessages
+    with Mockito {
 
   val identityHeaders = IdentityHeader("auth", "access-token")
 
-  val identityOauthHeaders = IdentityHeader("Bearer authorization_header", "unused_access_token", isOauth = true)
+  val identityOauthHeaders = IdentityHeader(
+    "Bearer authorization_header",
+    "unused_access_token",
+    isOauth = true
+  )
   "the identity service using Identity API" should {
     "return the user id when the identity api returns it" in new MockHttpRequestScope {
       val futureUserId = identityService.userFromRequest(identityHeaders, any())
@@ -36,21 +51,37 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     "the exception is caught when the request to identity fails" in new IdentityRequestFailsScope {
-      val idFailResult =  Await.ready(identityService.userFromRequest(identityHeaders, any()), Duration.Inf).value.get
+      val idFailResult = Await
+        .ready(
+          identityService.userFromRequest(identityHeaders, any()),
+          Duration.Inf
+        )
+        .value
+        .get
 
       idFailResult match {
         case Success(_) => fail("No IOxception thrown")
-        case Failure(e) => e mustEqual(IdentityApiRequestError("Did not get identiy api response"))
+        case Failure(e) =>
+          e mustEqual (IdentityApiRequestError(
+            "Did not get identiy api response"
+          ))
       }
 
     }
 
     "return future failed when identity returns 503" in new MockErrorResponseScope {
-      val idFailResult =  Await.ready(identityService.userFromRequest(identityHeaders, any()), Duration.Inf).value.get
+      val idFailResult = Await
+        .ready(
+          identityService.userFromRequest(identityHeaders, any()),
+          Duration.Inf
+        )
+        .value
+        .get
 
       idFailResult match {
         case Success(_) => fail("No IOxception thrown")
-        case Failure(e) => e mustEqual(IdentityApiRequestError("Identity api server error"))
+        case Failure(e) =>
+          e mustEqual (IdentityApiRequestError("Identity api server error"))
       }
 
     }
@@ -58,42 +89,73 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
 
   "the identity service using OAuth / Okta" should {
     "return the user id (identityId) from the oauth access token claims" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken[DefaultAccessClaims](AccessToken("authorization_header"), List(readSelf), DefaultAccessClaimsParser) returns
+      oktaLocalAccessTokenValidator
+        .parsedClaimsFromAccessToken[DefaultAccessClaims](
+          accessToken,
+          List(readSelf),
+          DefaultAccessClaimsParser
+        ) returns
         Right(DefaultAccessClaims("email", "1234", Some("username")))
-      val futureUserId = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
+      val futureUserId =
+        identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       Await.result(futureUserId, Duration.Inf) mustEqual (Some("1234"))
     }
 
     "return future failed when the oauth access token is invalid" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken[DefaultAccessClaims](AccessToken("authorization_header"), List(readSelf), DefaultAccessClaimsParser) returns Left(InvalidOrExpiredToken)
-      val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
+      oktaLocalAccessTokenValidator
+        .parsedClaimsFromAccessToken[DefaultAccessClaims](
+          accessToken,
+          List(readSelf),
+          DefaultAccessClaimsParser
+        ) returns Left(InvalidOrExpiredToken)
+      val futureFailed =
+        identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 
       futureFailedResult match {
         case Success(_) => fail("No IOexception thrown")
-        case Failure(e) => e mustEqual (OktaValidationException(InvalidOrExpiredToken))
+        case Failure(e) =>
+          e mustEqual (OktaValidationException(InvalidOrExpiredToken))
       }
     }
 
     "return future failed when the oauth access token has missing claims" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken[DefaultAccessClaims](AccessToken("authorization_header"), List(readSelf), DefaultAccessClaimsParser)  returns Left(MissingRequiredClaim("claim_name"))
-      val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(readSelf))
+      oktaLocalAccessTokenValidator
+        .parsedClaimsFromAccessToken[DefaultAccessClaims](
+          accessToken,
+          List(readSelf),
+          DefaultAccessClaimsParser
+        ) returns Left(MissingRequiredClaim("claim_name"))
+      val futureFailed =
+        identityService.userFromRequest(identityOauthHeaders, List(readSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 
       futureFailedResult match {
         case Success(_) => fail("No IOexception thrown")
-        case Failure(e) => e mustEqual (OktaValidationException(MissingRequiredClaim("claim_name")))
+        case Failure(e) =>
+          e mustEqual (OktaValidationException(
+            MissingRequiredClaim("claim_name")
+          ))
       }
     }
 
     "return future failed when the oauth access token has missing scope" in new MockHttpRequestScope {
-      oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken[DefaultAccessClaims](AccessToken("authorization_header"), List(updateSelf), DefaultAccessClaimsParser) returns Left(MissingRequiredScope(List(readSelf)))
-      val futureFailed = identityService.userFromRequest(identityOauthHeaders, List(updateSelf))
+      oktaLocalAccessTokenValidator
+        .parsedClaimsFromAccessToken[DefaultAccessClaims](
+          accessToken,
+          List(updateSelf),
+          DefaultAccessClaimsParser
+        ) returns Left(MissingRequiredScope(List(readSelf)))
+      val futureFailed =
+        identityService.userFromRequest(identityOauthHeaders, List(updateSelf))
       val futureFailedResult = Await.ready(futureFailed, Duration.Inf).value.get
 
       futureFailedResult match {
         case Success(_) => fail("No IOexception thrown")
-        case Failure(e) => e mustEqual (OktaValidationException(MissingRequiredScope(List(readSelf))))
+        case Failure(e) =>
+          e mustEqual (OktaValidationException(
+            MissingRequiredScope(List(readSelf))
+          ))
       }
     }
   }
@@ -106,7 +168,8 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
   }
 
   trait MockBadIdResponseScope extends MockHttpRequestScope {
-    override val body = """{"status":"error","errors":[{"message":"Access Denied","description":"Access Denied"}]}"""
+    override val body =
+      """{"status":"error","errors":[{"message":"Access Denied","description":"Access Denied"}]}"""
     override val code = 403
   }
 
@@ -117,10 +180,16 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
 
   trait MockHttpRequestScope extends Scope {
 
-    def buildResponse(request: Request, code: Int, body: Array[Byte]): Response = {
+    def buildResponse(
+        request: Request,
+        code: Int,
+        body: Array[Byte]
+    ): Response = {
       ResponseBody.create(GlobalHttpClient.applicationJsonMediaType, body)
       new Response.Builder()
-        .body(ResponseBody.create(GlobalHttpClient.applicationJsonMediaType, body))
+        .body(
+          ResponseBody.create(GlobalHttpClient.applicationJsonMediaType, body)
+        )
         .code(code)
         .protocol(Protocol.HTTP_1_1)
         .request(request)
@@ -142,6 +211,8 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
 
     val oktaLocalAccessTokenValidator = mock[OktaLocalAccessTokenValidator]
 
+    val accessToken = AccessToken("authorization_header")
+
     def theCallBack(callback: Callback, request: Request): Unit = {
       callback.onResponse(
         call,
@@ -150,18 +221,22 @@ class IdentityServiceSpec extends Specification with ThrownMessages with Mockito
     }
 
     httpClient.newCall(any[Request]()) answers {
-    (_: Any) match {
-      case (request: Request) => {
-        call.enqueue(any[Callback]()) answers {
-          (_: Any) match {
-            case (callback: Callback) => theCallBack(callback, request)
+      (_: Any) match {
+        case (request: Request) => {
+          call.enqueue(any[Callback]()) answers {
+            (_: Any) match {
+              case (callback: Callback) => theCallBack(callback, request)
+            }
           }
+          call
         }
-        call
       }
     }
-  }
-    val identityService = new IdentityServiceImpl(IdentityConfig(identityApiHost = "https://guardianidentiy.com"), httpClient, oktaLocalAccessTokenValidator)
+    val identityService = new IdentityServiceImpl(
+      IdentityConfig(identityApiHost = "https://guardianidentiy.com"),
+      httpClient,
+      oktaLocalAccessTokenValidator
+    )
   }
 
 }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/lambda/AwsLambdaSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/lambda/AwsLambdaSpec.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 
 class AwsLambdaSpec extends Specification with Mockito {
 
-    "AswLambda" should {
+    "AwsLambda" should {
       "Log but not error in" in {
         val mockedLogger = mock[Logger]
         val testException = new IllegalStateException("This is totally illegal")

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdkVersion = "1.11.412"
   val log4j2Version = "2.17.1"
-  val jacksonVersion = "2.13.4"
+  val jacksonVersion = "2.14.0"
   val specsVersion = "4.0.3"
 
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"
-  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.7"
+  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.11"
 
   //DependencyOverride
   val commonsLogging = "commons-logging" % "commons-logging" % "1.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"
-  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.11"
+  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.12"
 
   //DependencyOverride
   val commonsLogging = "commons-logging" % "commons-logging" % "1.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"
-  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.7"
+  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.12"
 
   //DependencyOverride
   val commonsLogging = "commons-logging" % "commons-logging" % "1.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"
-  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.12"
+  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.7"
 
   //DependencyOverride
   val commonsLogging = "commons-logging" % "commons-logging" % "1.2"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR updates the Mobile S4L's `identity-auth-core` dependency from 4.7 to 4.12. The `identity-auth-core` update from 4.7 to 4.8 was a breaking change, hence the changes needed to the IdentityService and tests as a result of this library update.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1. Automated tests pass
2. Snyk test no longer highlights a high vulnerability
3. Deployed to CODE and hit the saved articles POST and GET endpoints successfully.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Mobile apps continue to work as expected and we reduce the vulnerability count by 1

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
