### PR TITLE
Send snyk vulnerabilities to Personalisation organisation

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,7 +1,3 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
-# NOTE: This repository users master as the default branch (this file will need updating when it moves to main)
 name: Snyk
 
 on:
@@ -15,8 +11,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-# This org name will probably need to change based on your team
-      ORG: guardian-mobile
+      ORG: guardian-personalisation
       SKIP_NODE: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Since we now own this repository, it makes sense to push Mobile Save For Later based vulnerability warnings to the Personalisation Snyk organisation instead of the mobile one. I also deleted some outdated comments.

## How to test / How can we measure success?

I ran the Snyk github action manually based on this branch and the Mobile Save For Later repository appeared in the Personalisation Organisation, so this definitely works.

