### PR TITLE
Increase Mobile S4L Articles Dynamo Table write capacity to 125

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -11,7 +11,7 @@ Object {
       },
       "PROD": Object {
         "TableReadCapacity": 200,
-        "TableWriteCapacity": 75,
+        "TableWriteCapacity": 125,
       },
     },
   },
@@ -1084,7 +1084,7 @@ Object {
       },
       "PROD": Object {
         "TableReadCapacity": 200,
-        "TableWriteCapacity": 75,
+        "TableWriteCapacity": 125,
       },
     },
   },

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -41,4 +41,4 @@ Mappings:
       TableWriteCapacity: 1
     PROD:
       TableReadCapacity: 200
-      TableWriteCapacity: 75
+      TableWriteCapacity: 125


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is the initial attempt to address the following frequent alarm:

        High 5XX error % from mobile-save-for-later (ApiGateway) in PROD

Every instance of this alarm firing matches a spike in writes to the `mobile-save-for-later-PROD-articles` Dynamo table, with the provisioned capacity not able to meet the demand.

This initial PR simply bumps up the write capacity to cope with the daily demand. We'll run with this for a few days to check that the alarms fire less frequently, then look into an auto-scaling solution.

## How to test

Check the AWS UI to verify the write capacity has increased to 125 as expected. Monitor `P&E/Apps/ServerAlerts` over the coming days to see how often the alarm is firing.

## How can we measure success?

Fewer alarms firing.

## Have we considered potential risks?

This will increase costs for a few days, but it's a cheap monthly cost and hopefully we'll soon offset this with the savings from an auto-scaling solution.

## Images

1 hour time/x-axis difference down to UTC/daylight savings shenanigans

<img width="526" alt="image" src="https://github.com/guardian/mobile-save-for-later/assets/745953/ad683522-c1ca-4dca-882d-456930169ace">

![image](https://github.com/guardian/mobile-save-for-later/assets/745953/3c4093de-7179-42fc-8794-291eda263cf9)