### PR TITLE
Auto scaling s4l dynamodb

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -6,14 +6,16 @@ Object {
   "Mappings": Object {
     "StageVariables": Object {
       "CODE": Object {
-        "TableReadCapacity": 1,
+        "TableReadMaxCapacity": 10,
+        "TableReadMinCapacity": 1,
         "TableWriteMaxCapacity": 10,
         "TableWriteMinCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 200,
+        "TableReadMaxCapacity": 400,
+        "TableReadMinCapacity": 50,
         "TableWriteMaxCapacity": 400,
-        "TableWriteMinCapacity": 75,
+        "TableWriteMinCapacity": 50,
       },
     },
   },
@@ -574,7 +576,7 @@ Object {
               Object {
                 "Ref": "Stage",
               },
-              "TableReadCapacity",
+              "TableReadMinCapacity",
             ],
           },
           "WriteCapacityUnits": Object {
@@ -610,6 +612,55 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
+    },
+    "SaveForLaterReadsScalableTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableReadMaxCapacity",
+          ],
+        },
+        "MinCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableReadMinCapacity",
+          ],
+        },
+        "ResourceId": Object {
+          "Fn::Sub": "table/\${App}-\${Stage}-articles",
+        },
+        "RoleARN": Object {
+          "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+        },
+        "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "SaveForLaterReadsScalingPolicy": Object {
+      "Properties": Object {
+        "PolicyName": "SaveForLaterReadsScalingPolicy",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": Object {
+          "Ref": "SaveForLaterReadsScalableTarget",
+        },
+        "TargetTrackingScalingPolicyConfiguration": Object {
+          "PredefinedMetricSpecification": Object {
+            "PredefinedMetricType": "DynamoDBReadCapacityUtilization",
+          },
+          "ScaleInCooldown": 60,
+          "ScaleOutCooldown": 10,
+          "TargetValue": 70,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
     "SaveForLaterWritesScalableTarget": Object {
       "Properties": Object {
@@ -1130,14 +1181,16 @@ Object {
   "Mappings": Object {
     "StageVariables": Object {
       "CODE": Object {
-        "TableReadCapacity": 1,
+        "TableReadMaxCapacity": 10,
+        "TableReadMinCapacity": 1,
         "TableWriteMaxCapacity": 10,
         "TableWriteMinCapacity": 1,
       },
       "PROD": Object {
-        "TableReadCapacity": 200,
+        "TableReadMaxCapacity": 400,
+        "TableReadMinCapacity": 50,
         "TableWriteMaxCapacity": 400,
-        "TableWriteMinCapacity": 75,
+        "TableWriteMinCapacity": 50,
       },
     },
   },
@@ -1771,7 +1824,7 @@ Object {
               Object {
                 "Ref": "Stage",
               },
-              "TableReadCapacity",
+              "TableReadMinCapacity",
             ],
           },
           "WriteCapacityUnits": Object {
@@ -1807,6 +1860,55 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
+    },
+    "SaveForLaterReadsScalableTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableReadMaxCapacity",
+          ],
+        },
+        "MinCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableReadMinCapacity",
+          ],
+        },
+        "ResourceId": Object {
+          "Fn::Sub": "table/\${App}-\${Stage}-articles",
+        },
+        "RoleARN": Object {
+          "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+        },
+        "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "SaveForLaterReadsScalingPolicy": Object {
+      "Properties": Object {
+        "PolicyName": "SaveForLaterReadsScalingPolicy",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": Object {
+          "Ref": "SaveForLaterReadsScalableTarget",
+        },
+        "TargetTrackingScalingPolicyConfiguration": Object {
+          "PredefinedMetricSpecification": Object {
+            "PredefinedMetricType": "DynamoDBReadCapacityUtilization",
+          },
+          "ScaleInCooldown": 60,
+          "ScaleOutCooldown": 10,
+          "TargetValue": 70,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
     "SaveForLaterWritesScalableTarget": Object {
       "Properties": Object {

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -7,11 +7,13 @@ Object {
     "StageVariables": Object {
       "CODE": Object {
         "TableReadCapacity": 1,
-        "TableWriteCapacity": 1,
+        "TableWriteMaxCapacity": 10,
+        "TableWriteMinCapacity": 1,
       },
       "PROD": Object {
         "TableReadCapacity": 200,
-        "TableWriteCapacity": 125,
+        "TableWriteMaxCapacity": 400,
+        "TableWriteMinCapacity": 75,
       },
     },
   },
@@ -581,7 +583,7 @@ Object {
               Object {
                 "Ref": "Stage",
               },
-              "TableWriteCapacity",
+              "TableWriteMinCapacity",
             ],
           },
         },
@@ -608,6 +610,55 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
+    },
+    "SaveForLaterWritesScalableTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableWriteMaxCapacity",
+          ],
+        },
+        "MinCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableWriteMinCapacity",
+          ],
+        },
+        "ResourceId": Object {
+          "Fn::Sub": "table/\${App}-\${Stage}-articles",
+        },
+        "RoleARN": Object {
+          "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+        },
+        "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "SaveForLaterWritesScalingPolicy": Object {
+      "Properties": Object {
+        "PolicyName": "SaveForLaterWritesScalingPolicy",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": Object {
+          "Ref": "SaveForLaterWritesScalableTarget",
+        },
+        "TargetTrackingScalingPolicyConfiguration": Object {
+          "PredefinedMetricSpecification": Object {
+            "PredefinedMetricType": "DynamoDBWriteCapacityUtilization",
+          },
+          "ScaleInCooldown": 60,
+          "ScaleOutCooldown": 10,
+          "TargetValue": 70,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
     "fetcharticleslambda4E2BF026": Object {
       "DependsOn": Array [
@@ -1080,11 +1131,13 @@ Object {
     "StageVariables": Object {
       "CODE": Object {
         "TableReadCapacity": 1,
-        "TableWriteCapacity": 1,
+        "TableWriteMaxCapacity": 10,
+        "TableWriteMinCapacity": 1,
       },
       "PROD": Object {
         "TableReadCapacity": 200,
-        "TableWriteCapacity": 125,
+        "TableWriteMaxCapacity": 400,
+        "TableWriteMinCapacity": 75,
       },
     },
   },
@@ -1727,7 +1780,7 @@ Object {
               Object {
                 "Ref": "Stage",
               },
-              "TableWriteCapacity",
+              "TableWriteMinCapacity",
             ],
           },
         },
@@ -1754,6 +1807,55 @@ Object {
         ],
       },
       "Type": "AWS::DynamoDB::Table",
+    },
+    "SaveForLaterWritesScalableTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableWriteMaxCapacity",
+          ],
+        },
+        "MinCapacity": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "TableWriteMinCapacity",
+          ],
+        },
+        "ResourceId": Object {
+          "Fn::Sub": "table/\${App}-\${Stage}-articles",
+        },
+        "RoleARN": Object {
+          "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+        },
+        "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "SaveForLaterWritesScalingPolicy": Object {
+      "Properties": Object {
+        "PolicyName": "SaveForLaterWritesScalingPolicy",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": Object {
+          "Ref": "SaveForLaterWritesScalableTarget",
+        },
+        "TargetTrackingScalingPolicyConfiguration": Object {
+          "PredefinedMetricSpecification": Object {
+            "PredefinedMetricType": "DynamoDBWriteCapacityUtilization",
+          },
+          "ScaleInCooldown": 60,
+          "ScaleOutCooldown": 10,
+          "TargetValue": 70,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
     "fetcharticleslambda4E2BF026": Object {
       "DependsOn": Array [

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -17,12 +17,14 @@ Parameters:
 Mappings:
   StageVariables:
     CODE:
-      TableReadCapacity: 1
+      TableReadMinCapacity: 1
+      TableReadMaxCapacity: 10
       TableWriteMinCapacity: 1
       TableWriteMaxCapacity: 10
     PROD:
-      TableReadCapacity: 200
-      TableWriteMinCapacity: 75
+      TableReadMinCapacity: 50
+      TableReadMaxCapacity: 400
+      TableWriteMinCapacity: 50
       TableWriteMaxCapacity: 400
 
 Resources:
@@ -39,7 +41,7 @@ Resources:
           AttributeType: S
       ProvisionedThroughput:
         WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteMinCapacity ] # Initial value, autoscaled with below resources
-        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
+        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadMinCapacity ] # Initial value, autoscaled with below resources
 
   SaveForLaterWritesScalableTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -63,3 +65,26 @@ Resources:
         ScaleOutCooldown: 10
         PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
+          
+  SaveForLaterReadsScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: !FindInMap [StageVariables, !Ref Stage, TableReadMaxCapacity]
+      MinCapacity: !FindInMap [StageVariables, !Ref Stage, TableReadMinCapacity]
+      ResourceId: !Sub "table/${App}-${Stage}-articles"
+      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable
+      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+
+  SaveForLaterReadsScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: SaveForLaterReadsScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref SaveForLaterReadsScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 10
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -1,24 +1,3 @@
-Resources:
-  SaveForLaterDynamoTable:
-    DeletionPolicy: Retain
-    Type: 'AWS::DynamoDB::Table'
-    Properties:
-      KeySchema:
-        - KeyType: HASH
-          AttributeName: userId
-      TableName: !Sub '${App}-${Stage}-articles'
-      AttributeDefinitions:
-        - AttributeName: userId
-          AttributeType: S
-      ProvisionedThroughput:
-        WriteCapacityUnits: !FindInMap
-          - StageVariables
-          - !Ref Stage
-          - TableWriteCapacity
-        ReadCapacityUnits: !FindInMap
-          - StageVariables
-          - !Ref Stage
-          - TableReadCapacity
 Description: Implements save for later for mobile
 Parameters:
   DynamoNotificationTopic:
@@ -34,11 +13,53 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
+
 Mappings:
   StageVariables:
     CODE:
       TableReadCapacity: 1
-      TableWriteCapacity: 1
+      TableWriteMinCapacity: 1
+      TableWriteMaxCapacity: 10
     PROD:
       TableReadCapacity: 200
-      TableWriteCapacity: 125
+      TableWriteMinCapacity: 75
+      TableWriteMaxCapacity: 400
+
+Resources:
+  SaveForLaterDynamoTable:
+    DeletionPolicy: Retain
+    Type: 'AWS::DynamoDB::Table'
+    Properties:
+      KeySchema:
+        - KeyType: HASH
+          AttributeName: userId
+      TableName: !Sub '${App}-${Stage}-articles'
+      AttributeDefinitions:
+        - AttributeName: userId
+          AttributeType: S
+      ProvisionedThroughput:
+        WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteMinCapacity ] # Initial value, autoscaled with below resources
+        ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadCapacity ]
+
+  SaveForLaterWritesScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: !FindInMap [StageVariables, !Ref Stage, TableWriteMaxCapacity]
+      MinCapacity: !FindInMap [StageVariables, !Ref Stage, TableWriteMinCapacity]
+      ResourceId: !Sub "table/${App}-${Stage}-articles"
+      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+
+  SaveForLaterWritesScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: SaveForLaterWritesScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref SaveForLaterWritesScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 10
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds read and write autoscaling to the saved articles DynamoDB table. In the past we've been tweaking the provisioning [up](https://github.com/guardian/mobile-save-for-later/pull/78) and [down](https://github.com/guardian/mobile-save-for-later/pull/79) in response to the demands on the table. During spikes in traffic (such as when the queen died), the table can become grossly under-provisioned for a short period of time. We also see S4L usage fluctuate throughout the day.

It therefore makes sense to set up read/write autoscaling so that the table provisioning moves in response to the S4L usage throughout the day. It's been configured to scale out quickly (it will bump up capacity every 10 seconds if required), and scale back in more slowly (every 60 seconds) to ensure we maintain a decent level of service. I've set target utilisation to 70%, so there should always be a bit of wiggle room in the consumed:provisioned ratio. I set the minimum capacity values based on looking at graphs in the AWS console. I set the maximum capacity values based on the peaks we used for big news events in the past. So these figures are guesses rather than scientific but they seem sensible enough.

I found some examples throughout the Guardian codebase for inspiration:
* Previous PR by @frankie297: https://github.com/guardian/mobile-save-for-later/pull/56
* https://github.com/guardian/support-frontend/blob/85be2b88ec59adeb08e663aa03526a7e9c9ee10c/supporter-product-data/cloudformation/dynamo-tables.yaml#L44
* https://github.com/guardian/editorial-tools-platform/blob/0bf31787b27e05597701fa618b414560cf28ed60/cloudformation/media-service-account/grid/media-service.yaml#L1980

 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I've tested the setup of the minimum and maximum capacity units in the CODE environment by deploying this branch. Note that the values in the screenshot below differ as obviously we don't want to pay for unnecessarily high capacity in CODE.

<img width="785" alt="image" src="https://github.com/guardian/mobile-save-for-later/assets/745953/d8c771e4-35db-41bc-8eb0-9de83c86f89a">

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We should see fewer "High 5XX error % from mobile-save-for-later (ApiGateway) in PROD" alarms fired in the P&E/Apps/ServerAlerts

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
