### PR TITLE
Bump identity core to 4.15 to resolve bouncycastle vulnerability

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -1,6 +1,6 @@
 package com.gu.sfl.identity
 
-import com.gu.identity.auth.{AccessToken, DefaultAccessClaims, DefaultAccessClaimsParser, OktaLocalAccessTokenValidator, OktaValidationException, ValidationError, AccessScope => IdentityAccessScope}
+import com.gu.identity.auth.{AccessToken, DefaultAccessClaims, OktaLocalAccessTokenValidator, OktaValidationException, ValidationError, AccessScope => IdentityAccessScope}
 
 import java.io.IOException
 import com.gu.sfl.Logging
@@ -90,8 +90,7 @@ class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpCl
   def userFromRequestOauth(identityHeaders: IdentityHeader, requiredScope: List[IdentityAccessScope]): Either[ValidationError, DefaultAccessClaims] =
     oktaLocalAccessTokenValidator.parsedClaimsFromAccessToken(
       AccessToken(identityHeaders.auth.stripPrefix("Bearer ")),
-      requiredScope,
-      DefaultAccessClaimsParser
+      requiredScope
     )
 
   override def userFromRequest(identityHeaders: IdentityHeader, requiredScope: List[IdentityAccessScope]): Future[Option[String]] = {

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -3,7 +3,6 @@ package com.gu.sfl.identity
 import com.gu.identity.auth.{
   AccessToken,
   DefaultAccessClaims,
-  DefaultAccessClaimsParser,
   InvalidOrExpiredToken,
   MissingRequiredClaim,
   MissingRequiredScope,
@@ -92,8 +91,7 @@ class IdentityServiceSpec
       oktaLocalAccessTokenValidator
         .parsedClaimsFromAccessToken[DefaultAccessClaims](
           accessToken,
-          List(readSelf),
-          DefaultAccessClaimsParser
+          List(readSelf)
         ) returns
         Right(DefaultAccessClaims("email", "1234", Some("username")))
       val futureUserId =
@@ -105,8 +103,7 @@ class IdentityServiceSpec
       oktaLocalAccessTokenValidator
         .parsedClaimsFromAccessToken[DefaultAccessClaims](
           accessToken,
-          List(readSelf),
-          DefaultAccessClaimsParser
+          List(readSelf)
         ) returns Left(InvalidOrExpiredToken)
       val futureFailed =
         identityService.userFromRequest(identityOauthHeaders, List(readSelf))
@@ -123,8 +120,7 @@ class IdentityServiceSpec
       oktaLocalAccessTokenValidator
         .parsedClaimsFromAccessToken[DefaultAccessClaims](
           accessToken,
-          List(readSelf),
-          DefaultAccessClaimsParser
+          List(readSelf)
         ) returns Left(MissingRequiredClaim("claim_name"))
       val futureFailed =
         identityService.userFromRequest(identityOauthHeaders, List(readSelf))
@@ -143,8 +139,7 @@ class IdentityServiceSpec
       oktaLocalAccessTokenValidator
         .parsedClaimsFromAccessToken[DefaultAccessClaims](
           accessToken,
-          List(updateSelf),
-          DefaultAccessClaimsParser
+          List(updateSelf)
         ) returns Left(MissingRequiredScope(List(readSelf)))
       val futureFailed =
         identityService.userFromRequest(identityOauthHeaders, List(updateSelf))

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -6,8 +6,6 @@ object Dependencies {
   val jacksonVersion = "2.14.0"
   val specsVersion = "4.0.3"
 
-
-  //Dependecies
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0"
@@ -26,7 +24,7 @@ object Dependencies {
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"
   val specsMock = "org.specs2" %% "specs2-mock" % specsVersion % "test"
-  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.12"
+  val identityAuthCore = "com.gu.identity" %% "identity-auth-core" % "4.15"
 
   //DependencyOverride
   val commonsLogging = "commons-logging" % "commons-logging" % "1.2"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Bumps Identity Auth Core up to 4.15. This resolves a high vulnerability in the brilliantly named `bouncycastle` transitive dependency which was updated in the 4.15 release.

https://app.snyk.io/org/guardian-personalisation/project/d34cef19-1d16-41e4-b369-1aa662c5305f#issue-SNYK-JAVA-ORGBOUNCYCASTLE-6084022

https://github.com/guardian/identity/releases/tag/v4.15

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I deployed this branch to CODE, and ran Postman queries against the fetch and save endpoints. They worked as expected.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Snyk high vulnerability count reduces to by 1, and Mobile S4L continues to work in production as expected.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The Identity API had changed slightly so this was a tiny bit more work than just bumping up the version number, but the changes were trivial enough.

