### PR TITLE
Enable nightly backups for DynamoDB table

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -594,6 +594,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1841,6 +1845,10 @@ Object {
           "Fn::Sub": "\${App}-\${Stage}-articles",
         },
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/mobile-save-for-later/conf/cfn.yaml
+++ b/mobile-save-for-later/conf/cfn.yaml
@@ -42,6 +42,9 @@ Resources:
       ProvisionedThroughput:
         WriteCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableWriteMinCapacity ] # Initial value, autoscaled with below resources
         ReadCapacityUnits: !FindInMap [ StageVariables, !Ref Stage, TableReadMinCapacity ] # Initial value, autoscaled with below resources
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   SaveForLaterWritesScalableTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up `mobile-save-for-later`'s DynamoDB table using https://github.com/guardian/aws-backup.

For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

I think that snapshot testing is sufficient here. I will also check that backups are created after this change has been merged.

## How can we measure success?

We will be able to recover (most) article data stored in this table in the unlikely event that it is ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details. The doc mentions that the Mobile account might have greater costs than others, but this is primarily due to one very large table (not this one!). Backing up this table specifically should cost ~$12 per month.
