### PR TITLE
Allow building under Java 21 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,9 @@ import scala.collection.immutable
 
 val testAndCompileDependencies: String = "test->test;compile->compile"
 
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always // due to Identity using lift-json
+
 def projectMaker(projectName: String) = Project(projectName, file(projectName))
   .enablePlugins(RiffRaffArtifact)
   .settings(
@@ -27,9 +30,7 @@ def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] =
 
 val commonSettings: immutable.Seq[Def.Setting[_]] = List(
   fork := true, // was hitting deadlock, fxxund similar complaints online, disabling concurrency helps: https://github.com/sbt/sbt/issues/3022, https://github.com/mockito/mockito/issues/1067
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("releases")
-  ),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
   libraryDependencies ++= Seq(
     awsLambda,
     awsDynamo,
@@ -62,7 +63,7 @@ val commonSettings: immutable.Seq[Def.Setting[_]] = List(
   ),
   organization := "com.gu",
   version := "1.0",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.19",
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.6.1
+sbt.version=1.9.9
+


### PR DESCRIPTION
See https://github.com/guardian/scala-steward-public-repos/pull/68 ... we're now running our Scala Steward workflow with Java 21 LTS, which means that all projects that want to have Scala Steward updates (like this one) need to be able to build under Java 21 (even if the projects are still _running_ in production on Java 8).

_(unfortunately the Scala Steward run failing affects everyone, see https://github.com/guardian/scala-steward-public-repos/issues/60 - so I've removed `mobile-save-for-later` from Scala Steward until this PR is merged)_

Being able to build with Java 21 [requires](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-21-compatibility-notes) using recent versions of Scala (2.12.18+) and sbt (1.9.0+).


