### PR TITLE
Upgrade dynamo sync

### DIFF
--- a/common/src/main/scala/com/gu/sfl/persistence/SavedArticlesPersistence.scala
+++ b/common/src/main/scala/com/gu/sfl/persistence/SavedArticlesPersistence.scala
@@ -60,8 +60,8 @@ class SavedArticlesPersistenceImpl(persistanceConfig: PersistenceConfig) extends
    * Previously we had been using the put method to create new records,
    * however the put operation only supports return values of the old value or none
    * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
-   * Since we use the database response to respond to
-   *
+   * Since we use the database response to respond to the client, we want to have
+   * the latest data from the data
    * @param userId
    * @param savedArticles
    * @return savedArticles

--- a/common/src/main/scala/com/gu/sfl/persistence/SavedArticlesPersistence.scala
+++ b/common/src/main/scala/com/gu/sfl/persistence/SavedArticlesPersistence.scala
@@ -1,13 +1,12 @@
 package com.gu.sfl.persistence
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClient}
 import org.scanamo.{Scanamo, Table}
-import org.scanamo.auto._
 import org.scanamo.syntax._
 import com.gu.sfl.Logging
 import com.gu.sfl.lib.Jackson._
 import com.gu.sfl.model._
+import org.scanamo.generic.auto.genericDerivedFormat
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import scala.util.{Failure, Success, Try}
 
@@ -35,7 +34,7 @@ class SavedArticlesPersistenceImpl(persistanceConfig: PersistenceConfig) extends
     SavedArticles(dynamoSavedArticles.version, articles)
   }
 
-  private val client: AmazonDynamoDBAsync = AmazonDynamoDBAsyncClient.asyncBuilder().withCredentials(DefaultAWSCredentialsProviderChain.getInstance()).build()
+  private val client = DynamoDbClient.create()
   //TODO confirm that it's ok to share the same client concurrently in all requests.. I guess if this is a lambda there won't be concurrent requests anyway ?
   private val scanamo = Scanamo(client)
   private val table = Table[DynamoSavedArticles](persistanceConfig.tableName)

--- a/mobile-save-for-later-user-deletion/conf/cfn.yaml
+++ b/mobile-save-for-later-user-deletion/conf/cfn.yaml
@@ -147,7 +147,7 @@ Resources:
           SaveForLaterApp: !Sub ${SaveForLaterApp}
       Description: Lamba that deletes saved for later data for deleted users
       Handler: com.gu.sfl.userdeletion.UserDeletionLambda::handler
-      MemorySize: 384
+      MemorySize: 512
       Role: !GetAtt UserDeletionRole.Arn
       Runtime: java8
       Timeout: 300

--- a/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
+++ b/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
@@ -4,20 +4,24 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.dynamodbv2._
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import org.scanamo.{Scanamo, Table}
-import org.scanamo.auto._
 import org.scanamo.syntax._
 import com.gu.sfl.Logging
 import com.gu.sfl.persistence.{DynamoSavedArticles, PersistenceConfig}
 import com.gu.sfl.userdeletion.model.UserDeleteMessage
+import org.scanamo.DeleteReturn.OldValue
+import org.scanamo.generic.auto.genericDerivedFormat
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class SflDynamoDb(persistanceConfig: PersistenceConfig) extends Logging {
 
   private val table = Table[DynamoSavedArticles](persistanceConfig.tableName)
-  private val client: AmazonDynamoDB = AmazonDynamoDBClient.builder().withCredentials(DefaultAWSCredentialsProviderChain.getInstance()).build()
+  private val client = DynamoDbClient.create()
   private val scanamo = Scanamo(client)
   def deleteSavedArticleasForUser(user: UserDeleteMessage) = {
     logger.info(s"Deleting record for user id: ${user.userId}")
-    logger.info(Option(scanamo.exec(table.delete("userId" -> user.userId))).fold(s"Unable to delete record for user ${user.userId}")((_: DeleteItemResult) => s"Deleted record for ${user.userId}") )
+    val dbResponse = scanamo.exec(table.deleteAndReturn(OldValue)("userId" === user.userId))
+      .fold(s"Unable to delete record for user ${user.userId}")((_) => s"Deleted record for ${user.userId}")
+    logger.info(dbResponse)
   }
 
 }

--- a/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
+++ b/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
@@ -1,8 +1,5 @@
 package coml.gu.sfl.userdeletion.db
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.dynamodbv2._
-import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import org.scanamo.{Scanamo, Table}
 import org.scanamo.syntax._
 import com.gu.sfl.Logging

--- a/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
+++ b/mobile-save-for-later-user-deletion/src/main/scala/coml/gu/sfl/userdeletion/db/SflDynamoDb.scala
@@ -5,9 +5,10 @@ import org.scanamo.syntax._
 import com.gu.sfl.Logging
 import com.gu.sfl.persistence.{DynamoSavedArticles, PersistenceConfig}
 import com.gu.sfl.userdeletion.model.UserDeleteMessage
-import org.scanamo.DeleteReturn.OldValue
+import org.scanamo.DeleteReturn.Nothing
 import org.scanamo.generic.auto.genericDerivedFormat
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
 
 class SflDynamoDb(persistanceConfig: PersistenceConfig) extends Logging {
 
@@ -16,7 +17,7 @@ class SflDynamoDb(persistanceConfig: PersistenceConfig) extends Logging {
   private val scanamo = Scanamo(client)
   def deleteSavedArticleasForUser(user: UserDeleteMessage) = {
     logger.info(s"Deleting record for user id: ${user.userId}")
-    val dbResponse = scanamo.exec(table.deleteAndReturn(OldValue)("userId" === user.userId))
+    val dbResponse = scanamo.exec(table.deleteAndReturn(Nothing)("userId" === user.userId))
       .fold(s"Unable to delete record for user ${user.userId}")((_) => s"Deleted record for ${user.userId}")
     logger.info(dbResponse)
   }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lib/SavedArticlesMerger.scala
@@ -49,7 +49,7 @@ class SavedArticlesMergerImpl(savedArticlesMergerConfig: SavedArticlesMergerConf
         persistMergedArticles(userId, articlesToSave)(savedArticlesPersistence.update)
       case Success(None) =>
         logger.info(s"UserId: $userId. Storing articles for the first time. Version: ${deduplicatedArticles.version}. Client count: ${deduplicatedArticles.articles.length}")
-        persistMergedArticles(userId, deduplicatedArticles)(savedArticlesPersistence.write)
+        persistMergedArticles(userId, deduplicatedArticles)(savedArticlesPersistence.update)
       case _ => Left(SavedArticleMergeError("Could not retrieve current articles"))
     }
   }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -4,12 +4,12 @@ object Dependencies {
   val awsSdkVersion = "1.11.412"
   val log4j2Version = "2.17.1"
   val jacksonVersion = "2.14.0"
-  val specsVersion = "4.0.3"
+  val specsVersion = "4.20.5"
 
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0"
-  val awsJavaSdk ="com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion
+  val awsJavaSdk = "software.amazon.awssdk" % "dynamodb" % "2.24.11"
   val awsSqs ="com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
   val awsLambdaEvent = "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"
 
@@ -19,7 +19,7 @@ object Dependencies {
   val jacksonJsrDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
   val log4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j2Version
   val commonsIo = "commons-io" % "commons-io" % "2.6"
-  val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
+  val scanamo = "org.scanamo" %% "scanamo" % "1.0.1"
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.9.2"
   val specsCore = "org.specs2" %% "specs2-core" % specsVersion % "test"
   val specsScalaCheck = "org.specs2" %% "specs2-scalacheck" % specsVersion % "test"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
   val awsDynamo ="com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   val awsLambdaLog = "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0"
-  val awsJavaSdk = "software.amazon.awssdk" % "dynamodb" % "2.24.11"
+  val awsJavaSdk = "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion
   val awsSqs ="com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
   val awsLambdaEvent = "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR does the job of upgrading the scanamo and dynamo library ahead of a larger upgrade to Java11. 

Changes: 

- Amazon client from Async to Sync. 

This was to maintain the type signatures as the AsyncScanamo returns a Future, and this would introduce much larger code changes. I don't think there should be operational reasons that we would need an async client in this case. It would be good to confirm this point. 

- Removes the write method which calls dyanmo's put method, in favour of calling `update` for both create and update requests. 

This is because put item https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html does not return the latest version of data in the data store. However update item https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html does. 
The code is using the data returned from the database in the response back to the client. 

## How to test

Using the iOS Simulator
- [x] Able to display saved articles
- [x] Able to remove all articles
- [x] Able to add a new article

Using the lambda console
- [x] Ability to delete a user
