### PR TITLE
Upgrade the TLS

### DIFF
--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -96,6 +96,7 @@ Object {
           ],
         },
         "DomainName": "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
+        "SecurityPolicy": "TLS_1_2",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -1289,6 +1290,7 @@ Object {
           ],
         },
         "DomainName": "mobile-save-for-later.mobile-aws.guardianapis.com",
+        "SecurityPolicy": "TLS_1_2",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -128,6 +128,7 @@ export class MobileSaveForLater extends GuStack {
     const cfnDomainName = new CfnDomainName(this, "ApiDomainName", {
       domainName: props.domainName,
       certificateArn,
+      securityPolicy: "TLS_1_2",
     });
 
     new CfnBasePathMapping(this, "ApiMapping", {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades the TLS version to the latest supported for API Gateway: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html#cfn-apigateway-domainname-securitypolicy
as we have been informed our current TLS cipher is insecure https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html 
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
