### PR TITLE
Explicity include netty handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val commonSettings: immutable.Seq[Def.Setting[_]] = List(
     jacksonDataFormat,
     jacksonJsrDataType,
     commonsIo,
+    nettyHandler,
     scanamo,
     okHttp,
     slf4jSimple,

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   val jacksonVersion = "2.18.2"
   val specsVersion = "4.20.9"
   val http4sVersion = "0.23.26"
+  val nettyVersion = "4.1.118.Final"
 
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.3"
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
@@ -36,6 +37,7 @@ object Dependencies {
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.25"
   val apacheLog4JCore = "org.apache.logging.log4j" % "log4j-core" % log4j2Version
   val apacheLog$jApi = "org.apache.logging.log4j" % "log4j-api" % log4j2Version % "provided"
+  val nettyHandler = "io.netty" % "netty-handler" % nettyVersion
 
   val  slf4jSimple = "org.slf4j" % "slf4j-simple" % "2.0.16"
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades the version of netty in response to a security notification: https://github.com/advisories/GHSA-4g8c-wm8x-jfhw

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
