### PR TITLE
Include error message in log statement

### DIFF
--- a/common/src/main/scala/com/gu/sfl/Logging.scala
+++ b/common/src/main/scala/com/gu/sfl/Logging.scala
@@ -11,7 +11,7 @@ trait Logging {
   def logOnThrown[T](function: () => T, messageOnError: String = ""): T = Try(function()) match {
     case Success(value) => value
     case Failure(throwable) =>
-      logger.warn(messageOnError, throwable)
+      logger.error(s"$messageOnError: ${throwable.getMessage}", throwable)
       throw throwable
   }
 }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/AwsLambda.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/AwsLambda.scala
@@ -16,9 +16,9 @@ abstract class AwsLambda(function: LambdaRequest => Future[LambdaResponse]) exte
   private val lambdaApiGateway = new LambdaApiGatewayImpl(function)
 
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
-    Try(lambdaApiGateway.execute(input, output)).recover {
-      case t: Throwable => logger.warn("Error executing lambda: ", t)
-        throw t
+    Try(lambdaApiGateway.execute(input, output)).recover { err =>
+      logger.error(s"Error executing lambda: ${err.getMessage()}", err)
+      throw err
     }
   }
 }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/lambda/AwsLambdaSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/lambda/AwsLambdaSpec.scala
@@ -25,7 +25,7 @@ class AwsLambdaSpec extends Specification with Mockito {
         ).recover {
           case t => t must beEqualTo(testException)
         }
-        there was one(mockedLogger).warn(s"Error executing lambda: ", testException)
+        there was one(mockedLogger).error(s"Error executing lambda: This is totally illegal", testException)
 
       }
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This updates the exception logging to include the errors message in the first line of the log statement. When I needed to debug this service it was difficult to identify the exception logs with the where they were being throw because it appears on a separate line in the logs. 

See 
![log-statement](https://github.com/user-attachments/assets/fbdd9fb7-ab5e-4a05-a4ee-f271c2d7111e)

Adding the error message to the first log statement should make it easier to search on exceptions being thrown 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
