### PR TITLE
Raise lambda concurrency limit to 500

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -28,7 +28,7 @@ export const prodProps: MobileSaveForLaterProps = {
   hostedZoneName: "mobile-aws.guardianapis.com",
   hostedZoneId: "Z1EYB4AREPXE3B",
   identityApiHost: "https://id.guardianapis.com",
-  reservedConcurrentExecutions: 300,
+  reservedConcurrentExecutions: 500,
   monitoringConfiguration: {
     snsTopicName: "mobile-server-side",
     http5xxAlarm: {

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -2024,7 +2024,7 @@ Object {
         "FunctionName": "mobile-save-for-later-FETCH-cdk-PROD",
         "Handler": "com.gu.sfl.lambda.FetchArticlesLambda::handleRequest",
         "MemorySize": 1024,
-        "ReservedConcurrentExecutions": 300,
+        "ReservedConcurrentExecutions": 500,
         "Role": Object {
           "Fn::GetAtt": Array [
             "fetcharticleslambdaServiceRoleC5815D5D",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


- We often get 5xx errors from api gateway due to the lambda hitting the max concurrency (currently 300).
<img width="1314" height="295" alt="image" src="https://github.com/user-attachments/assets/44c04b3d-f55e-4e04-96d1-2652085d9498" />

- Raising the limit to 500 should reduce throttles and 5xx errors when there is a traffic spike.
- The lambda cost for this service isn't significant at the moment (~$50 to ~$85 per month) so don't expect this to raise a cost concern.


## How to test
Monitor the service in the next couple of weeks and see if we get fewer error alerts.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
