### PR TITLE
chore: Remove support for legacy User Access Tokens from Save For Later

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The service is implemented as a pair of aws [lambda functions](https://aws.amazon.com/lambda/) set behind aws [api gateway](https://aws.amazon.com/api-gateway) which you can view and test by going to the api gateway section of the console [here](https://eu-west-1.console.aws.amazon.com/apigateway/home?region=eu-west-1#/apis) 
 
-There's a fetch function (`/syncedPrefs/me`)(GET) and a update function(http POST) `/syncedPrefs/me/savedArticles`. Each endpoint requires a `authorisation` header containing a valid access token. This is used to retrieve the userId from the identity api. 
+There's a fetch function (`/syncedPrefs/me`)(GET) and a update function(http POST) `/syncedPrefs/me/savedArticles`. Each endpoint requires a `authorisation` header containing a valid access token, which can be decoded to get a users's userId. 
 
 To update saved articles a json body is required: This should take the forms
 
@@ -27,7 +27,7 @@ To update saved articles a json body is required: This should take the forms
             }]
          }
          
-Here the `version` property is a timesamp and the `articles` array is all of the users currently saved articles. The version property is used to ensure that saved articles can be synced accross different devices
+Here the `version` property is a timesamp and the `articles` array is all of the users currently saved articles. The version property is used to ensure that saved articles can be synced across different devices
 
 ### User Help Queries
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,7 +12,6 @@ export const codeProps: MobileSaveForLaterProps = {
   domainName: "mobile-save-for-later.mobile-aws.code.dev-guardianapis.com",
   hostedZoneName: "mobile-aws.code.dev-guardianapis.com",
   hostedZoneId: "Z6PRU8YR6TQDK",
-  identityApiHost: "https://id.code.dev-guardianapis.com",
   reservedConcurrentExecutions: 1,
   monitoringConfiguration: { noMonitoring: true },
   identityOktaIssuerUrl:
@@ -27,7 +26,6 @@ export const prodProps: MobileSaveForLaterProps = {
   domainName: "mobile-save-for-later.mobile-aws.guardianapis.com",
   hostedZoneName: "mobile-aws.guardianapis.com",
   hostedZoneId: "Z1EYB4AREPXE3B",
-  identityApiHost: "https://id.guardianapis.com",
   reservedConcurrentExecutions: 500,
   monitoringConfiguration: {
     snsTopicName: "mobile-server-side",

--- a/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-save-for-later.test.ts.snap
@@ -745,7 +745,6 @@ Object {
           "Variables": Object {
             "APP": "mobile-save-for-later",
             "App": "mobile-save-for-later",
-            "IdentityApiHost": "https://id.code.dev-guardianapis.com",
             "IdentityOktaAudience": "https://profile.code.dev-theguardian.com/",
             "IdentityOktaIssuerUrl": "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7",
             "STACK": "mobile",
@@ -975,7 +974,6 @@ Object {
           "Variables": Object {
             "APP": "mobile-save-for-later",
             "App": "mobile-save-for-later",
-            "IdentityApiHost": "https://id.code.dev-guardianapis.com",
             "IdentityOktaAudience": "https://profile.code.dev-theguardian.com/",
             "IdentityOktaIssuerUrl": "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7",
             "STACK": "mobile",
@@ -2012,7 +2010,6 @@ Object {
           "Variables": Object {
             "APP": "mobile-save-for-later",
             "App": "mobile-save-for-later",
-            "IdentityApiHost": "https://id.guardianapis.com",
             "IdentityOktaAudience": "https://profile.theguardian.com/",
             "IdentityOktaIssuerUrl": "https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417",
             "STACK": "mobile",
@@ -2242,7 +2239,6 @@ Object {
           "Variables": Object {
             "APP": "mobile-save-for-later",
             "App": "mobile-save-for-later",
-            "IdentityApiHost": "https://id.guardianapis.com",
             "IdentityOktaAudience": "https://profile.theguardian.com/",
             "IdentityOktaIssuerUrl": "https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417",
             "STACK": "mobile",

--- a/cdk/lib/mobile-save-for-later.ts
+++ b/cdk/lib/mobile-save-for-later.ts
@@ -18,7 +18,6 @@ export interface MobileSaveForLaterProps extends GuStackProps {
   domainName: string;
   hostedZoneName: string;
   hostedZoneId: string;
-  identityApiHost: string;
   reservedConcurrentExecutions: number;
   monitoringConfiguration: NoMonitoring | ApiGatewayAlarms;
   identityOktaIssuerUrl: string;
@@ -50,7 +49,6 @@ export class MobileSaveForLater extends GuStack {
       App: app,
       Stack: this.stack,
       Stage: this.stage,
-      IdentityApiHost: props.identityApiHost,
       IdentityOktaIssuerUrl: props.identityOktaIssuerUrl,
       IdentityOktaAudience: props.identityOktaAudience,
     };

--- a/docs/testing/save-for-later.md
+++ b/docs/testing/save-for-later.md
@@ -46,7 +46,7 @@ in the oauth flow
 
 * Go to the drop down menu between the build and play button and select `Edit Configurations`
 * Add the following environment variables:
-  `App=mobile-save-for-later;IdentityApiHost=https://id.code.dev-guardianapis.com;IdentityOktaAudience=https://profile.code.dev-theguardian.com/;IdentityOktaIssuerUrl=https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7;Stage=CODE;SavedArticleLimit=100`
+  `App=mobile-save-for-later;IdentityOktaAudience=https://profile.code.dev-theguardian.com/;IdentityOktaIssuerUrl=https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7;Stage=CODE;SavedArticleLimit=100`
 * Press the green play button
 * Follow the same steps as above for testing endpoints in the rest client by changing the urls to:
 GET: `http://localhost:8888/syncedPrefs/me`

--- a/docs/testing/user-deletion.md
+++ b/docs/testing/user-deletion.md
@@ -42,7 +42,7 @@
 * Make sure `mobile-save-for-later-user-deletion` is selected for the module dropdown
 * Check that `local.RunUserDeletionLambda` is selected in the Main Module field
 * Add the following environment variables:
-  `App=mobile-save-for-later;IdentityApiHost=https://id.code.dev-guardianapis.com;IdentityOktaAudience=https://profile.code.dev-theguardian.com/;IdentityOktaIssuerUrl=https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7;Stage=CODE;SavedArticleLimit=100;SaveForLaterApp=mobile-save-for-later`
+  `App=mobile-save-for-later;IdentityOktaAudience=https://profile.code.dev-theguardian.com/;IdentityOktaIssuerUrl=https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7;Stage=CODE;SavedArticleLimit=100;SaveForLaterApp=mobile-save-for-later`
 * Modify `src/main/resources/delete-event.json` to have the user id you want (inside `"body"` > `"message"` > `"userId"` value)
 * Hit the green run button
 * If successful, you should see `Deleted record for <user-id>` in the terminal (unless the user already doesn't exist in the database, in which case `Unable to delete record for user <user-id>`).

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/identity/IdentityService.scala
@@ -1,17 +1,11 @@
 package com.gu.sfl.identity
 
 import com.gu.identity.auth.{AccessToken, DefaultAccessClaims, OktaLocalAccessTokenValidator, OktaValidationException, ValidationError, AccessScope => IdentityAccessScope}
-
-import java.io.IOException
 import com.gu.sfl.Logging
-import com.gu.sfl.exception.IdentityApiRequestError
-import com.gu.sfl.lib.Jackson._
-import okhttp3._
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
-
-case class IdentityConfig(identityApiHost: String)
+import java.security.MessageDigest
+import java.util.HexFormat
+import scala.concurrent.Future
 
 case class IdentityHeader(auth: String, accessToken: String = "Bearer application_token", isOauth: Boolean = false)
 
@@ -34,57 +28,11 @@ object AccessScope {
 trait IdentityService {
   def userFromRequest(identityHeaders: IdentityHeader, requiredScope: List[IdentityAccessScope]) : Future[Option[String]]
 }
-class IdentityServiceImpl(identityConfig: IdentityConfig, okHttpClient: OkHttpClient, oktaLocalAccessTokenValidator: OktaLocalAccessTokenValidator)(implicit executionContext: ExecutionContext) extends IdentityService with Logging {
+class IdentityServiceImpl(oktaLocalAccessTokenValidator: OktaLocalAccessTokenValidator) extends IdentityService with Logging {
   def userFromRequestIdapi(identityHeaders: IdentityHeader): Future[Option[String]] = {
-    val meUrl = s"${identityConfig.identityApiHost}/user/me/identifiers"
-
-    val headers = new Headers.Builder()
-      .add("X-GU-ID-Client-Access-Token", identityHeaders.accessToken)
-      .add("Authorization", identityHeaders.auth)
-      .build()
-
-    val promise = Promise[Option[String]]
-
-    val request = new Request.Builder()
-      .url(meUrl)
-      .headers(headers)
-      .get()
-      .build()
-
-    def extractUserIdFromSuccessResult(response: Response) = {
-      Try {
-        val body = response.body().string()
-        logger.debug(s"Identity api response: $body")
-        val node = mapper.readTree(body.getBytes)
-        node.path("id").textValue
-      } match {
-        case Success(userId) =>
-          // .textValue can return null, so wrap in Option.apply
-          promise.success(Option(userId))
-        case Failure(_) =>
-          promise.success(None)
-      }
-    }
-
-    okHttpClient.newCall(
-      request
-    ).enqueue(new Callback {
-      override def onResponse(call: Call, response: Response): Unit = {
-        val responseCodeGroup = response.code() / 100
-
-        // 5XX responses should not log users out, so fail the promise instead of returning None
-        if (responseCodeGroup == 5) {
-          promise.failure(IdentityApiRequestError("Identity api server error"))
-        } else if (responseCodeGroup == 2) {
-          extractUserIdFromSuccessResult(response)
-        } else {
-          promise.success(None)
-        }
-      }
-
-      override def onFailure(call: Call, e: IOException): Unit = promise.failure(IdentityApiRequestError("Did not get identiy api response"))
-    })
-    promise.future
+    val tokenBytes = MessageDigest.getInstance("SHA-256").digest(identityHeaders.auth.getBytes("UTF-8"))
+    logger.warn(s"Detected legacy User Access Token instead of Okta Access Token. Hash: ${HexFormat.of().formatHex(tokenBytes)}" )
+    Future.successful(None)
   }
 
   def userFromRequestOauth(identityHeaders: IdentityHeader, requiredScope: List[IdentityAccessScope]): Either[ValidationError, DefaultAccessClaims] =

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/FetchArticlesLambda.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/FetchArticlesLambda.scala
@@ -3,16 +3,14 @@ package com.gu.sfl.lambda
 import com.gu.identity.auth.{OktaAudience, OktaIssuerUrl, OktaLocalAccessTokenValidator, OktaTokenValidationConfig}
 import com.gu.sfl.Logging
 import com.gu.sfl.controller.FetchArticlesController
-import com.gu.sfl.identity.{IdentityConfig, IdentityServiceImpl}
+import com.gu.sfl.identity.IdentityServiceImpl
 import com.gu.sfl.lambda.AwsLambda.readEnvKey
 import com.gu.sfl.lambda.FetchArticlesConfig.{app, stage}
 import com.gu.sfl.lib.Parallelism.largeGlobalExecutionContext
-import com.gu.sfl.lib.GlobalHttpClient
 import com.gu.sfl.persistence.{PersistenceConfig, SavedArticlesPersistenceImpl}
 import com.gu.sfl.savedarticles.FetchSavedArticlesImpl
 
 object FetchArticlesConfig {
-  lazy val identityApiHost = readEnvKey("IdentityApiHost")
   lazy val app = readEnvKey("App")
   lazy val stage = readEnvKey("Stage")
   lazy val identityOktaIssuerUrl = readEnvKey("IdentityOktaIssuerUrl")
@@ -26,8 +24,6 @@ object FetchArticlesLambda extends Logging {
       new FetchArticlesController(
         new FetchSavedArticlesImpl(
           new IdentityServiceImpl(
-            IdentityConfig(FetchArticlesConfig.identityApiHost),
-            GlobalHttpClient.defaultHttpClient,
             OktaLocalAccessTokenValidator.fromConfig(
               OktaTokenValidationConfig(
                 OktaIssuerUrl(FetchArticlesConfig.identityOktaIssuerUrl),

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/SaveArticlesLambda.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/lambda/SaveArticlesLambda.scala
@@ -2,7 +2,7 @@ package com.gu.sfl.lambda
 import com.gu.identity.auth.{OktaAudience, OktaIssuerUrl, OktaLocalAccessTokenValidator, OktaTokenValidationConfig}
 import com.gu.sfl.Logging
 import com.gu.sfl.controller.SaveArticlesController
-import com.gu.sfl.identity.{IdentityConfig, IdentityServiceImpl}
+import com.gu.sfl.identity.IdentityServiceImpl
 import com.gu.sfl.lambda.AwsLambda.readEnvKey
 import com.gu.sfl.lambda.SaveArticlesConfig.{app, stage}
 import com.gu.sfl.lib.Parallelism.largeGlobalExecutionContext
@@ -10,8 +10,6 @@ import com.gu.sfl.lib.{GlobalHttpClient, SavedArticlesMergerConfig, SavedArticle
 import com.gu.sfl.persistence.{PersistenceConfig, SavedArticlesPersistenceImpl}
 import com.gu.sfl.savedarticles.UpdateSavedArticlesImpl
 object SaveArticlesConfig {
-
-  lazy val identityApiHost: String = readEnvKey("IdentityApiHost")
   lazy val app: String = readEnvKey("App")
   lazy val stage: String = readEnvKey("Stage")
   lazy val savedArticleLimit: Int = readEnvKey("SavedArticleLimit").toInt
@@ -24,8 +22,6 @@ object SaveArticlesLambda extends Logging {
           new SaveArticlesController(
             new UpdateSavedArticlesImpl(
               new IdentityServiceImpl(
-                IdentityConfig(SaveArticlesConfig.identityApiHost),
-                GlobalHttpClient.defaultHttpClient,
                 OktaLocalAccessTokenValidator.fromConfig(
                   OktaTokenValidationConfig(
                     OktaIssuerUrl(SaveArticlesConfig.identityOktaIssuerUrl),

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/identity/IdentityServiceSpec.scala
@@ -1,27 +1,19 @@
 package com.gu.sfl.identity
 
-import com.gu.identity.auth.{
-  AccessToken,
-  DefaultAccessClaims,
-  InvalidOrExpiredToken,
-  MissingRequiredClaim,
-  MissingRequiredScope,
-  OktaLocalAccessTokenValidator,
-  OktaValidationException
-}
+import com.gu.identity.auth.{AccessToken, DefaultAccessClaims, InvalidOrExpiredToken, MissingRequiredClaim, MissingRequiredScope, OktaLocalAccessTokenValidator, OktaValidationException}
 
 import java.io.IOException
-import com.gu.sfl.exception.IdentityApiRequestError
 import com.gu.sfl.identity.AccessScope.{readSelf, updateSelf}
 import com.gu.sfl.lib.GlobalHttpClient
 import okhttp3._
 import org.specs2.matcher.ThrownMessages
 import org.specs2.mock.Mockito
+import org.mockito.Mockito._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 import scala.concurrent.Await
-import com.gu.sfl.lib.Parallelism.largeGlobalExecutionContext
+import org.slf4j.Logger
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -39,50 +31,11 @@ class IdentityServiceSpec
     isOauth = true
   )
   "the identity service using Identity API" should {
-    "return the user id when the identity api returns it" in new MockHttpRequestScope {
-      val futureUserId = identityService.userFromRequest(identityHeaders, any())
-      Await.result(futureUserId, Duration.Inf) mustEqual (Some("1234"))
-    }
-
-    "return none when the user id is not found" in new MockBadIdResponseScope {
+    "return none and log a hashed access token" in new MockBadIdResponseScope {
       val futureUserId = identityService.userFromRequest(identityHeaders, any())
       Await.result(futureUserId, Duration.Inf) mustEqual (None)
-    }
 
-    "the exception is caught when the request to identity fails" in new IdentityRequestFailsScope {
-      val idFailResult = Await
-        .ready(
-          identityService.userFromRequest(identityHeaders, any()),
-          Duration.Inf
-        )
-        .value
-        .get
-
-      idFailResult match {
-        case Success(_) => fail("No IOxception thrown")
-        case Failure(e) =>
-          e mustEqual (IdentityApiRequestError(
-            "Did not get identiy api response"
-          ))
-      }
-
-    }
-
-    "return future failed when identity returns 503" in new MockErrorResponseScope {
-      val idFailResult = Await
-        .ready(
-          identityService.userFromRequest(identityHeaders, any()),
-          Duration.Inf
-        )
-        .value
-        .get
-
-      idFailResult match {
-        case Success(_) => fail("No IOxception thrown")
-        case Failure(e) =>
-          e mustEqual (IdentityApiRequestError("Identity api server error"))
-      }
-
+      verify(mockedLogger).warn("Detected legacy User Access Token instead of Okta Access Token. Hash: bdf49c3c3882102fc017ffb661108c63a836d065888a4093994398cc55c2ea2f")
     }
   }
 
@@ -205,6 +158,7 @@ class IdentityServiceSpec
     val call = mock[Call]
 
     val oktaLocalAccessTokenValidator = mock[OktaLocalAccessTokenValidator]
+    val mockedLogger = mock[Logger]
 
     val accessToken = AccessToken("authorization_header")
 
@@ -228,10 +182,10 @@ class IdentityServiceSpec
       }
     }
     val identityService = new IdentityServiceImpl(
-      IdentityConfig(identityApiHost = "https://guardianidentiy.com"),
-      httpClient,
       oktaLocalAccessTokenValidator
-    )
+    ) {
+      override val logger: Logger = mockedLogger
+    }
   }
 
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've slowly been decomissioning the infrastructure to support legacy User Access Tokens which were replaced by Okta Oauth Tokens a few years ago. However, this lambda seems to still regularly invoke Identity API ~400 per day using them. We are currently planning on removing support for this legacy authentication mechanism in https://github.com/guardian/identity/pull/3049

We believe that these calls are being made by older versions of the apps that still haven't updated yet. This PR removes support for these legacy tokens, which will likely break the app for these users, updating their app and signing in again should fix their access however and not impact their saved for later feed.

Based on data from [Identity API](https://github.com/guardian/identity/pull/3049), and this Lambda, we believe that most of these tokens will expire by the end of next month anyway, and that the vast majority of traffic to the Save For Later API uses Okta authentication instead.

## How has this change been tested?

Deployed to CODE and tested both the fetch and update lambdas using a valid Okta token, and an invalid User Access Token. I was able to sucessfully update my saved for later articles using the Okta token.