### PR TITLE
Fix date-time parse error handling and return 400 API response instead of 5xx

### DIFF
--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -5,7 +5,7 @@ import com.gu.sfl.exception.{IdentityServiceError, MissingAccessTokenError, Okta
 import com.gu.sfl.lambda.{LambdaRequest, LambdaResponse}
 import com.gu.sfl.lib.Base64Utils
 import com.gu.sfl.lib.Jackson._
-import com.gu.sfl.model.{DirtySavedArticles, SavedArticles}
+import com.gu.sfl.model.{DirtySavedArticles, Error, SavedArticles}
 import com.gu.sfl.savedarticles.UpdateSavedArticles
 import com.gu.sfl.util.StatusCodes
 
@@ -26,7 +26,7 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
           case Failure(t) => {
             val headersWithoutAuth = lambdaRequest.headers.filter{ case (k,v) => headersToKeep.contains(k.toLowerCase)}
             logger.warn(s"Could not read value: $json \nWith headers: $headersWithoutAuth" )
-            Future { LambdaResponse(StatusCodes.badRequest, Some("Could not parse request body")) }
+            Future { lambdaErrorResponse(StatusCodes.badRequest, List(Error("Bad Request", "Could not parse request body"))) }
           }
           case _ => futureSave(triedSavedArticles, lambdaRequest.headers)
         }

--- a/mobile-save-for-later/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
+++ b/mobile-save-for-later/src/main/scala/com/gu/sfl/controller/SaveArticlesController.scala
@@ -26,11 +26,10 @@ class SaveArticlesController(updateSavedArticles: UpdateSavedArticles)(implicit 
           case Failure(t) => {
             val headersWithoutAuth = lambdaRequest.headers.filter{ case (k,v) => headersToKeep.contains(k.toLowerCase)}
             logger.warn(s"Could not read value: $json \nWith headers: $headersWithoutAuth" )
+            Future { LambdaResponse(StatusCodes.badRequest, Some("Could not parse request body")) }
           }
-
-          case _ => ()
+          case _ => futureSave(triedSavedArticles, lambdaRequest.headers)
         }
-        futureSave(triedSavedArticles, lambdaRequest.headers)
       case LambdaRequest(None,  _) =>
         Future { LambdaResponse(StatusCodes.badRequest, Some("Expected a json body")) }
     }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
@@ -1,0 +1,54 @@
+package com.gu.sfl.controller
+
+import com.gu.sfl.exception.SaveForLaterError
+import com.gu.sfl.lambda.LambdaRequest
+import com.gu.sfl.model.SavedArticles
+import com.gu.sfl.savedarticles.UpdateSavedArticles
+import com.gu.sfl.util.StatusCodes
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class SaveArticlesControllerSpec extends Specification with Mockito {
+
+  "SaveArticlesController" should {
+
+    "return a 400 when the date on an article is not in the expected format" in new Setup {
+      val json = """{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date":"2026-07-16T10:15:30.123Z","read":false}]}"""
+      val response = Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
+
+      response.statusCode mustEqual StatusCodes.badRequest
+      there were no(updateSavedArticles).save(any[Map[String, String]](), any[SavedArticles]())
+    }
+
+    "return a 400 when the request body is not valid json" in new Setup {
+      val response = Await.result(controller(LambdaRequest(Some("not json"))), Duration.Inf)
+
+      response.statusCode mustEqual StatusCodes.badRequest
+    }
+
+    "return a 400 when there is no request body" in new Setup {
+      val response = Await.result(controller(LambdaRequest(None)), Duration.Inf)
+
+      response.statusCode mustEqual StatusCodes.badRequest
+    }
+
+    "attempt to save the articles when the date is in the expected format" in new Setup {
+      val json = """{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date":"2026-07-16T10:15:30Z","read":false}]}"""
+      updateSavedArticles.save(any[Map[String, String]](), any[SavedArticles]()) returns Future.successful(Left(mock[SaveForLaterError]))
+
+      Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
+
+      there was one(updateSavedArticles).save(any[Map[String, String]](), any[SavedArticles]())
+    }
+  }
+
+  trait Setup extends Scope {
+    implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
+    val updateSavedArticles = mock[UpdateSavedArticles]
+    val controller = new SaveArticlesController(updateSavedArticles)
+  }
+}

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
@@ -15,9 +15,19 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class SaveArticlesControllerSpec extends Specification with Mockito {
 
   "SaveArticlesController" should {
+    "save the articles when the date is in the expected format" in new Setup {
+      val validDateTimeString = "2026-07-16T10:15:30Z"
+      val json = s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$validDateTimeString","read":false}]}"""
+      updateSavedArticles.save(any[Map[String, String]](), any[SavedArticles]()) returns Future.successful(Left(mock[SaveForLaterError]))
 
-    "return a 400 when the date on an article is not in the expected format" in new Setup {
-      val json = """{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date":"2026-07-16T10:15:30.123Z","read":false}]}"""
+      Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
+
+      there was one(updateSavedArticles).save(any[Map[String, String]](), any[SavedArticles]())
+    }
+
+    "return a 400 when the date is not in the expected format" in new Setup {
+      val invalidDateTimeString = "Fri Jan 01 08:00:01 GMT+08:00 2010"
+      val json = s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$invalidDateTimeString","read":false}]}"""
       val response = Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
 
       response.statusCode mustEqual StatusCodes.badRequest
@@ -34,15 +44,6 @@ class SaveArticlesControllerSpec extends Specification with Mockito {
       val response = Await.result(controller(LambdaRequest(None)), Duration.Inf)
 
       response.statusCode mustEqual StatusCodes.badRequest
-    }
-
-    "attempt to save the articles when the date is in the expected format" in new Setup {
-      val json = """{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date":"2026-07-16T10:15:30Z","read":false}]}"""
-      updateSavedArticles.save(any[Map[String, String]](), any[SavedArticles]()) returns Future.successful(Left(mock[SaveForLaterError]))
-
-      Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
-
-      there was one(updateSavedArticles).save(any[Map[String, String]](), any[SavedArticles]())
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Currently `SaveArticlesController`, when a client sends a date string that doesn't match the expected date/time format (ISO), the exception isn't caught anywhere in the request-handling chain so it propagates as an unhandled failure, crashing the lambda and causing API gateway to return 502 instead of the correct 400 error. 
- Update the controller to return 400 Bad Request directly on JSON deserialisation error.
- Added unit tests

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Tested on CODE

|        | CODE response |
|--------|---------------|
| before |   <img width="812" height="367" alt="image" src="https://github.com/user-attachments/assets/cb79537a-70ac-4930-b7e5-b6f9cd27fdcf" />   |
| after  |  <img width="812" height="478" alt="image" src="https://github.com/user-attachments/assets/16a2080b-4a82-4d6d-9b40-d1f526200058" /> |