### PR TITLE
Accept milliseconds in request date field

### DIFF
--- a/common/src/main/scala/com/gu/sfl/model/model.scala
+++ b/common/src/main/scala/com/gu/sfl/model/model.scala
@@ -1,7 +1,8 @@
 package com.gu.sfl.model
 
 import java.io.IOException
-import java.time.format.DateTimeFormatter
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -80,7 +81,13 @@ case class ErrorResponse(status: String = "error", errors: List[Error])
 case class Error(message: String, description: String)
 
 object SavedArticleDateSerializer {
-  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+  /** Accept optional 3-digit milliseconds in input parsing since it is a valid ISO-8601 component
+   *  But drop them during output serialisation to ensure consistency in DB records and API responses
+  */
+  val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS]'Z'")
+  val outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+
+  def parse(value: String): LocalDateTime = LocalDateTime.parse(value, inputFormatter)
 }
 
 class DirtySavedArticleDeserializer(t: Class[DirtySavedArticle]) extends StdDeserializer[DirtySavedArticle](t)  {
@@ -93,7 +100,7 @@ class DirtySavedArticleDeserializer(t: Class[DirtySavedArticle]) extends StdDese
     val id = Option(node.get("id")).filter(_.isTextual).map(_.asText())
     val shortUrl = Option(node.get("shortUrl")).filter(_.isTextual).map(_.asText())
     val read = Option(node.get("read")).filter(_.isBoolean).map(_.asBoolean())
-    val date = Option(node.get("date")).filter(_.isTextual).map(_.asText()).map(LocalDateTime.parse(_, SavedArticleDateSerializer.formatter))
+    val date = Option(node.get("date")).filter(_.isTextual).map(_.asText()).map(SavedArticleDateSerializer.parse)
     DirtySavedArticle(id, shortUrl, date, read.getOrElse(false))
   }
 }
@@ -109,7 +116,7 @@ class SavedArticleSerializer(t:Class[SavedArticle]) extends StdSerializer[SavedA
     gen.writeStartObject()
     gen.writeStringField("id", value.id)
     gen.writeStringField("shortUrl", value.shortUrl)
-    gen.writeStringField("date", SavedArticleDateSerializer.formatter.format(value.date))
+    gen.writeStringField("date", SavedArticleDateSerializer.outputFormatter.format(value.date))
     gen.writeBooleanField("read", value.read)
     gen.writeEndObject()
   }

--- a/common/src/test/scala/com/gu/sfl/model/SavedArticleDateSerializerTest.scala
+++ b/common/src/test/scala/com/gu/sfl/model/SavedArticleDateSerializerTest.scala
@@ -1,0 +1,28 @@
+package com.gu.sfl.model
+
+import java.time.LocalDateTime
+
+import org.specs2.mutable.Specification
+
+class SavedArticleDateSerializerTest extends Specification {
+  "SavedArticleDateSerializer.parse" should {
+    "parse a date without milliseconds" in {
+      SavedArticleDateSerializer.parse("2026-07-17T10:15:30Z") must beEqualTo(
+        LocalDateTime.of(2026, 7, 17, 10, 15, 30)
+      )
+    }
+
+    "parse a date with milliseconds" in {
+      SavedArticleDateSerializer.parse("2026-07-17T10:15:30.123Z") must beEqualTo(
+        LocalDateTime.of(2026, 7, 17, 10, 15, 30, 123000000)
+      )
+    }
+  }
+
+  "SavedArticleDateSerializer.outputFormatter" should {
+    "always write dates without milliseconds" in {
+      val date = LocalDateTime.of(2026, 7, 17, 10, 15, 30, 123000000)
+      SavedArticleDateSerializer.outputFormatter.format(date) must beEqualTo("2026-07-17T10:15:30Z")
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Clients can send dates with milliseconds (`e.g.2026-07-17T10:15:30.123Z`) which is valid ISO-8601 but our parser. is too strict at the moment so will reject it.
- Create an input parser formatter which optionally accepts 3 digit milliseconds. 
- For output, we continue to use the existing formatter (renamed to `outputFormatter`) to ensure consistency in our output in API response and DB writes
- Add unit tests

## How has this change been tested?
Deployed to CODE and tested on Android emulator

**Test request body** (date/time with milliseconds)
<img width="688" height="395" alt="image" src="https://github.com/user-attachments/assets/ddf32e4f-bfb5-4f37-8338-9fa1ce2af5b9" />

**Before the current change**
400 Bad Request
<img width="688" height="350" alt="image" src="https://github.com/user-attachments/assets/322dd889-3843-4059-a392-c4ad28026845" />

**After the current change**
200 (with the millis seconds dropped)
<img width="551" height="401" alt="image" src="https://github.com/user-attachments/assets/4cfe72a9-5ced-42bf-ad35-6dde259089b0" />



