### PR TITLE
Revert "Temporarily accept Java's default `Date.toString()` format in save requests"

### DIFF
--- a/common/src/main/scala/com/gu/sfl/model/model.scala
+++ b/common/src/main/scala/com/gu/sfl/model/model.scala
@@ -1,11 +1,9 @@
 package com.gu.sfl.model
 
 import java.io.IOException
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
-import java.util.Locale
-
-import scala.util.Try
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
+import java.time.{Instant, LocalDateTime, ZoneOffset}
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser, JsonProcessingException}
@@ -92,24 +90,8 @@ object SavedArticleDateSerializer {
   def parse(value: String): LocalDateTime = LocalDateTime.parse(value, inputFormatter)
 }
 
-// TEMPORARY: the Android client currently sends dates using Java's default Date#toString format
-// instead of ISO-8601. This object and its use below should be deleted once the client is fixed
-// to only ever send the ISO format used by SavedArticleDateSerializer above (Task ticket: https://app.asana.com/1/1210045093164357/project/1215309367148854/task/1216728547635263)
-object JavaDefaultDateFormat {
-  // matches java.util.Date#toString, e.g. "Fri Jan 01 00:00:01 GMT 2010" or "Fri Jan 01 08:00:01 GMT+08:00 2010"
-  val formatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH)
-}
-
 class DirtySavedArticleDeserializer(t: Class[DirtySavedArticle]) extends StdDeserializer[DirtySavedArticle](t)  {
   def this () = this(null)
-
-  // TEMPORARY: accept both the ISO format and the legacy Java default format until the client
-  // is updated to always send ISO. Remove the fallback (and JavaDefaultDateFormat above) once
-  // that migration is complete (Task ticket: https://app.asana.com/1/1210045093164357/project/1215309367148854/task/1216728547635263).
-  private def parseDate(text: String): LocalDateTime =
-    Try(SavedArticleDateSerializer.parse(text))
-      .getOrElse(ZonedDateTime.parse(text, JavaDefaultDateFormat.formatter).toLocalDateTime)
-
   @Override
   @throws(classOf[IOException])
   @throws(classOf[JsonProcessingException])
@@ -118,7 +100,7 @@ class DirtySavedArticleDeserializer(t: Class[DirtySavedArticle]) extends StdDese
     val id = Option(node.get("id")).filter(_.isTextual).map(_.asText())
     val shortUrl = Option(node.get("shortUrl")).filter(_.isTextual).map(_.asText())
     val read = Option(node.get("read")).filter(_.isBoolean).map(_.asBoolean())
-    val date = Option(node.get("date")).filter(_.isTextual).map(_.asText()).map(parseDate)
+    val date = Option(node.get("date")).filter(_.isTextual).map(_.asText()).map(SavedArticleDateSerializer.parse)
     DirtySavedArticle(id, shortUrl, date, read.getOrElse(false))
   }
 }

--- a/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
+++ b/mobile-save-for-later/src/test/scala/com/gu/sfl/controller/SaveArticlesControllerSpec.scala
@@ -2,15 +2,13 @@ package com.gu.sfl.controller
 
 import com.gu.sfl.exception.SaveForLaterError
 import com.gu.sfl.lambda.LambdaRequest
-import com.gu.sfl.lib.Jackson._
-import com.gu.sfl.model.{SavedArticle, SavedArticles, SavedArticlesResponse}
+import com.gu.sfl.model.SavedArticles
 import com.gu.sfl.savedarticles.UpdateSavedArticles
 import com.gu.sfl.util.StatusCodes
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
-import java.time.LocalDateTime
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -28,7 +26,7 @@ class SaveArticlesControllerSpec extends Specification with Mockito {
     }
 
     "return a 400 when the date is not in the expected format" in new Setup {
-      val invalidDateTimeString = "2010-01-01 00:00:01" // missing the T separator and trailing Z
+      val invalidDateTimeString = "Fri Jan 01 08:00:01 GMT+08:00 2010"
       val json = s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$invalidDateTimeString","read":false}]}"""
       val response = Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
 
@@ -47,61 +45,6 @@ class SaveArticlesControllerSpec extends Specification with Mockito {
 
       response.statusCode mustEqual StatusCodes.badRequest
     }
-
-    /*
-     * ==================== TEMPORARY: start of java-default-format fallback tests ====================
-     *
-     * The 3 tests below were added while we temporarily accept the java-default-format fallback
-     * while Android fixes their bug in sending the incorrect format. These tests exist only to
-     * document and pin down the temporary fallback behaviour, and MUST fail (or get removed) once
-     * that fallback is gone.
-     *
-     * Task ticket: https://app.asana.com/1/1210045093164357/project/1215309367148854/task/1216728547635263
-     */
-    "save the articles when the date is in the java default format" in new Setup {
-      val javaDefaultDateTimeString = "Fri Jan 01 00:00:01 GMT 2010"
-      val json =
-        s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$javaDefaultDateTimeString","read":false}]}"""
-
-      updateSavedArticles.save(any[Map[String, String]](), any[SavedArticles]()) returns
-        Future.successful(Left(mock[SaveForLaterError]))
-
-      Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
-
-      there was one(updateSavedArticles).save(any[Map[String, String]](), any[SavedArticles]())
-    }
-
-    "save the java default format date to the db as the correct parsed LocalDateTime" in new Setup {
-      val javaDefaultDateTimeString = "Fri Jan 01 00:00:01 GMT 2010"
-      val expectedDateTime = LocalDateTime.of(2010, 1, 1, 0, 0, 1)
-      val json =
-        s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$javaDefaultDateTimeString","read":false}]}"""
-
-      val savedArticlesCaptor = capture[SavedArticles]
-      updateSavedArticles.save(any[Map[String, String]](), savedArticlesCaptor) returns
-        Future.successful(Left(mock[SaveForLaterError]))
-
-      Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
-
-      savedArticlesCaptor.value.articles.head.date mustEqual expectedDateTime
-    }
-
-    "return the java default format date in the API response as an ISO SavedArticle" in new Setup {
-      val javaDefaultDateTimeString = "Fri Jan 01 00:00:01 GMT 2010"
-      val expectedArticle = SavedArticle("id/1", "p/1", LocalDateTime.of(2010, 1, 1, 0, 0, 1), read = false)
-      val json =
-        s"""{"version":"1","articles":[{"id":"id/1","shortUrl":"p/1","date": "$javaDefaultDateTimeString","read":false}]}"""
-
-      updateSavedArticles.save(any[Map[String, String]](), any[SavedArticles]()) answers { (_: Any) match {
-        case Array(_, savedArticles: SavedArticles) => Future.successful(Right(savedArticles))
-      }}
-
-      val response = Await.result(controller(LambdaRequest(Some(json))), Duration.Inf)
-      val parsedResponse = mapper.readValue[SavedArticlesResponse](response.maybeBody.get)
-
-      parsedResponse.savedArticles.articles mustEqual List(expectedArticle)
-    }
-    /* ==================== TEMPORARY: end of java-default-format fallback tests ==================== */
   }
 
   trait Setup extends Scope {


### PR DESCRIPTION
Reverts guardian/mobile-save-for-later#234

We believe enough Android users are on later app versions sending the correct ISO so let's clean up the Java date/time fallback logic